### PR TITLE
🚸 ux(booleans): display warning when using --flag false instead of --flag=false

### DIFF
--- a/cmd/prerun/false.go
+++ b/cmd/prerun/false.go
@@ -1,0 +1,19 @@
+package prerun
+
+import (
+	"os"
+	"slices"
+
+	"github.com/mattn/go-isatty"
+	"github.com/outscale/gli/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func CheckFalse(cmd *cobra.Command, args []string) {
+	if !isatty.IsTerminal(os.Stdout.Fd()) {
+		return
+	}
+	if slices.Contains(args, "false") {
+		errors.Warn("⚠️ --flag false does not work, use --flag=false")
+	}
+}

--- a/cmd/prerun/update.go
+++ b/cmd/prerun/update.go
@@ -24,7 +24,7 @@ func CheckUpdate(cmd *cobra.Command, args []string) {
 	defer cancel()
 	latest, err := update.LatestRelease(ghCtx)
 	if err != nil {
-		errors.Warn("❌ Unable to fetch latest release: %v\n", err)
+		errors.Info("❌ Unable to fetch latest release: %v", err)
 		return
 	}
 	debug.Println("check update", version.Version, latest, semver.Compare(version.Version, latest) < 0)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ var rootCmd = &cobra.Command{
 `) + d(`one CLI to bring them all
 `) + e(`and in the terminal bind them.`),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		prerun.CheckFalse(cmd, args)
 		prerun.CheckUpdate(cmd, args)
 	},
 }

--- a/pkg/errors/exit.go
+++ b/pkg/errors/exit.go
@@ -19,7 +19,3 @@ func Exit(code int, format string, a ...any) {
 func ExitErr(err error) {
 	Exit(1, "an error occurred: %v", err)
 }
-
-func Warn(format string, a ...any) {
-	_, _ = color.New(color.FgYellow).Add(color.Faint).Fprintf(os.Stderr, format, a...)
-}

--- a/pkg/errors/warn.go
+++ b/pkg/errors/warn.go
@@ -1,0 +1,15 @@
+package errors
+
+import (
+	"os"
+
+	"github.com/fatih/color"
+)
+
+func Info(format string, a ...any) {
+	_, _ = color.New(color.FgYellow).Add(color.Faint).Fprintf(os.Stderr, format+"\n", a...)
+}
+
+func Warn(format string, a ...any) {
+	_, _ = color.New(color.FgYellow).Fprintf(os.Stderr, format+"\n", a...)
+}


### PR DESCRIPTION
## Description

A boolean flag can be set to false with `--flag=false`. Using `--flag false` looks OK, but sends true, not false.

This PR displays a warning when `--flag false` is used.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [x] Other (specify): UX

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
