### PR TITLE
🚸 ux(times): allow durations or day/month/year offsets in time-based flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,11 @@ gli iaas api ReadVms --Filters.VmStateNames running
 The flag syntax is:
 * list of values are comma-separated: `--Filters.VmStateNames running,stopped`,
 * boolean flags can be set to false by setting: `--TmpEnabled=false`,
-* lists of embedded objects (e.g. `Nics` or `BlockDeviceMappings` in `CreateVms`) can be configured using indexes: `--BlockDeviceMappings.0.Bsu.VolumeType`.
+* lists of embedded objects (e.g. `Nics` or `BlockDeviceMappings` in `CreateVms`) can be configured using indexes: `--BlockDeviceMappings.0.Bsu.VolumeType`,
+* time flag values can be set:
+  * using the RFC3339 format (e.g. `2026-02-10T14:52:30Z`),
+  * as a duration offset with a `+` or `-` prefix (e.g. `+10m`, `-1h`),
+  * as a day/month/year offset with a `+` or `-` prefix (e.g. `+1mo`, `-1y`).
 
 ### Chaining
 

--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -9,9 +9,12 @@ import (
 	"encoding/json"
 	"reflect"
 	"strconv"
+	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/outscale/gli/pkg/config"
+	"github.com/outscale/gli/pkg/flags"
+	"github.com/outscale/osc-sdk-go/v3/pkg/iso8601"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 )
@@ -103,12 +106,12 @@ func (b *Builder[T]) BuildAPI(rootCmd *cobra.Command, methodFilter func(m reflec
 			Run:     run,
 		}
 		arg := m.Type.In(2)
-		b.BuildArg(cmd, arg, "")
+		b.BuildFlags(cmd, arg, "")
 		apiCmd.AddCommand(cmd)
 	}
 }
 
-func (b *Builder[T]) BuildArg(cmd *cobra.Command, arg reflect.Type, prefix string) {
+func (b *Builder[T]) BuildFlags(cmd *cobra.Command, arg reflect.Type, prefix string) {
 	typeName := arg.Name()
 	fs := cmd.Flags()
 	for i := range arg.NumField() {
@@ -147,19 +150,26 @@ func (b *Builder[T]) BuildArg(cmd *cobra.Command, arg reflect.Type, prefix strin
 			case reflect.Int:
 				fs.IntSlice(prefix+f.Name, nil, help)
 			case reflect.Struct:
-				if t.Elem().Implements(reflect.TypeFor[json.Marshaler]()) {
+				switch {
+				case ot == reflect.TypeFor[iso8601.Time]() || ot == reflect.TypeFor[time.Time]():
+					// TODO: add slice
+					fs.Var(flags.NewTimeValue(), prefix+f.Name, help)
+				case t.Elem().Implements(reflect.TypeFor[json.Marshaler]()):
 					fs.StringSlice(prefix+f.Name, nil, help)
-				} else {
+				default:
 					for i := range NumEntriesInSlices {
-						b.BuildArg(cmd, t.Elem(), prefix+f.Name+"."+strconv.Itoa(i)+".")
+						b.BuildFlags(cmd, t.Elem(), prefix+f.Name+"."+strconv.Itoa(i)+".")
 					}
 				}
 			}
 		case reflect.Struct:
-			if ot.Implements(reflect.TypeFor[json.Marshaler]()) {
+			switch {
+			case t == reflect.TypeFor[iso8601.Time]() || t == reflect.TypeFor[time.Time]():
+				fs.Var(flags.NewTimeValue(), prefix+f.Name, help)
+			case ot.Implements(reflect.TypeFor[json.Marshaler]()):
 				fs.String(prefix+f.Name, "", help)
-			} else {
-				b.BuildArg(cmd, t, prefix+f.Name+".")
+			default:
+				b.BuildFlags(cmd, t, prefix+f.Name+".")
 			}
 		}
 	}

--- a/pkg/flags/time.go
+++ b/pkg/flags/time.go
@@ -1,0 +1,83 @@
+package flags
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/outscale/osc-sdk-go/v3/pkg/iso8601"
+)
+
+var Now = time.Now
+
+// TimeValue adapts time.Time for use as a flag.
+type TimeValue struct {
+	t *time.Time
+}
+
+func NewTimeValue() *TimeValue {
+	return &TimeValue{t: &time.Time{}}
+}
+
+// Set time.Time value from string (rfc3339, iso8601 or duration).
+func (d *TimeValue) Set(s string) error {
+	s = strings.TrimSpace(s)
+	// try a iso8601 time
+	v, err := iso8601.Parse([]byte(s))
+	if err == nil {
+		*d.t = v
+		return nil
+	}
+	s = strings.TrimPrefix(s, "+")
+	// it might have been a duration
+	dur, err := time.ParseDuration(s)
+	if err == nil {
+		*d.t = Now().Add(dur)
+		return nil
+	}
+	// or a day/month/year offset
+	switch {
+	case strings.HasSuffix(s, "d"):
+		n, err := strconv.Atoi(s[:len(s)-1])
+		if err != nil {
+			return fmt.Errorf("invalid day offset %q: %w", s, err)
+		}
+		*d.t = Now().AddDate(0, 0, n)
+		return nil
+	case strings.HasSuffix(s, "mo"):
+		n, err := strconv.Atoi(s[:len(s)-2])
+		if err != nil {
+			return fmt.Errorf("invalid month offset %q: %w", s, err)
+		}
+		*d.t = Now().AddDate(0, n, 0)
+		return nil
+	case strings.HasSuffix(s, "y"):
+		n, err := strconv.Atoi(s[:len(s)-1])
+		if err != nil {
+			return fmt.Errorf("invalid year offset %q: %w", s, err)
+		}
+		*d.t = Now().AddDate(n, 0, 0)
+		return nil
+	}
+	return fmt.Errorf("invalid time format %q", s)
+}
+
+// Type name for time.Time flags.
+func (d *TimeValue) Type() string {
+	return "osctime"
+}
+
+func (d *TimeValue) String() string {
+	if d.t == nil || d.t.IsZero() {
+		return ""
+	}
+	return d.t.Format(time.RFC3339Nano)
+}
+
+func (d *TimeValue) Value() (time.Time, bool) {
+	if d.t == nil {
+		return time.Time{}, false
+	}
+	return *d.t, true
+}

--- a/pkg/flags/time_test.go
+++ b/pkg/flags/time_test.go
@@ -1,0 +1,102 @@
+package flags_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/outscale/gli/pkg/flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeValue(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	flags.Now = func() time.Time {
+		return now
+	}
+	t.Run("RFC3339 times work", func(t *testing.T) {
+		v := flags.NewTimeValue()
+		err := v.Set(now.Format(time.RFC3339))
+		require.NoError(t, err)
+		vts, ok := v.Value()
+		assert.True(t, ok)
+		assert.True(t, now.Equal(vts))
+	})
+	t.Run("ISO8601 times work", func(t *testing.T) {
+		v := flags.NewTimeValue()
+		err := v.Set("2025-07-17T15:23:08.000+0000")
+		require.NoError(t, err)
+		vts, ok := v.Value()
+		assert.True(t, ok)
+		assert.Equal(t, "2025-07-17T15:23:08Z", vts.Format(time.RFC3339))
+	})
+
+	t.Run("durations work", func(t *testing.T) {
+		v := flags.NewTimeValue()
+		{
+			err := v.Set("+1h")
+			require.NoError(t, err)
+			vts, ok := v.Value()
+			assert.True(t, ok)
+			assert.Equal(t, now.Add(time.Hour), vts)
+		}
+		{
+			err := v.Set("-1h")
+			require.NoError(t, err)
+			vts, ok := v.Value()
+			assert.True(t, ok)
+			assert.Equal(t, now.Add(-time.Hour), vts)
+		}
+	})
+	t.Run("day delta work", func(t *testing.T) {
+		v := flags.NewTimeValue()
+		{
+			err := v.Set("+1d")
+			require.NoError(t, err)
+			vts, ok := v.Value()
+			assert.True(t, ok)
+			assert.Equal(t, now.AddDate(0, 0, 1), vts)
+		}
+		{
+			err := v.Set("-1d")
+			require.NoError(t, err)
+			vts, ok := v.Value()
+			assert.True(t, ok)
+			assert.Equal(t, now.AddDate(0, 0, -1), vts)
+		}
+	})
+	t.Run("month delta work", func(t *testing.T) {
+		v := flags.NewTimeValue()
+		{
+			err := v.Set("+1mo")
+			require.NoError(t, err)
+			vts, ok := v.Value()
+			assert.True(t, ok)
+			assert.Equal(t, now.AddDate(0, 1, 0), vts)
+		}
+		{
+			err := v.Set("-1mo")
+			require.NoError(t, err)
+			vts, ok := v.Value()
+			assert.True(t, ok)
+			assert.Equal(t, now.AddDate(0, -1, 0), vts)
+		}
+	})
+	t.Run("year delta work", func(t *testing.T) {
+		v := flags.NewTimeValue()
+		{
+			err := v.Set("+1y")
+			require.NoError(t, err)
+			vts, ok := v.Value()
+			assert.True(t, ok)
+			assert.Equal(t, now.AddDate(1, 0, 0), vts)
+		}
+		{
+			err := v.Set("-1y")
+			require.NoError(t, err)
+			vts, ok := v.Value()
+			assert.True(t, ok)
+			assert.Equal(t, now.AddDate(-1, 0, 0), vts)
+		}
+	})
+}


### PR DESCRIPTION
# 📦 Pull Request Template

## Description

This PR allows setting a time flag with an offset : `+1h` (now + 1 hour), `-15m` (now - 15 minutes), `+1d` (now + 1 day), `-1mo` (now - 1 month).

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [x] Other (specify): ux

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
