### PR TITLE
💄 ui(confirm): use borders for confirm options

### DIFF
--- a/pkg/builder/prompt.go
+++ b/pkg/builder/prompt.go
@@ -43,6 +43,8 @@ func confirm(action config.Action, display, run func(cmd *cobra.Command, args []
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title(prompts[action]).
+					Affirmative("✅ Yes").
+					Negative("❌ No").
 					Value(&yes),
 			),
 		).WithTheme(style.Theme()).Run()

--- a/pkg/style/style.go
+++ b/pkg/style/style.go
@@ -21,5 +21,15 @@ var (
 func Theme() *huh.Theme {
 	t := huh.ThemeBase()
 	t.Focused.Title = t.Focused.Title.Foreground(lipgloss.Color("184"))
+	t.Focused.FocusedButton = t.Focused.FocusedButton.
+		Border(lipgloss.NormalBorder()).
+		BorderForeground(lipgloss.AdaptiveColor{Light: "236", Dark: "254"}).
+		Foreground(lipgloss.AdaptiveColor{Light: "0", Dark: "15"}).
+		Background(lipgloss.NoColor{})
+	t.Focused.BlurredButton = t.Focused.BlurredButton.
+		Border(lipgloss.NormalBorder()).
+		BorderForeground(lipgloss.AdaptiveColor{Light: "254", Dark: "236"}).
+		Foreground(lipgloss.AdaptiveColor{Light: "239", Dark: "248"}).
+		Background(lipgloss.NoColor{})
 	return t
 }


### PR DESCRIPTION
## Description

The defaults button style was confusing in light mode. This PR sets borders to the buttons with specific light mode colors.

It also adds emoji to confirm buttons, because emojis.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [x] Other (specify): ui

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
