### PR TITLE
✨ feat(columns): + to add columns to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ octl <command> <command>
 | `--config` | `~/.osc/config.json` | | config file path |
 | `--profile` | `default` | | profile name |
 | `--output` | | `raw`, `json`, `yaml`, `table` | output format |
-| `--columns` | | | columns to display in a table (`title:field,title:field`) |
+| `--columns` | | | columns to display in a table |
 
 ### Output formats
 
@@ -183,9 +183,9 @@ VolumeId: vol-foo
 VolumeType: io1
 ```
 
-Columns can be changed:
+Columns can be replaced:
 ```shell
-octl iaas vm list --columns ID:VmId,DNS:PrivateDnsName
+octl iaas vm list --columns "ID:VmId|DNS:PrivateDnsName"
 ┌────────────┬───────────────────────────────────────────┐
 │     ID     │                    DNS                    │
 ├────────────┼───────────────────────────────────────────┤
@@ -194,6 +194,17 @@ octl iaas vm list --columns ID:VmId,DNS:PrivateDnsName
 │ i-baz      │ ip-10-0-4-143.eu-west-2.compute.internal  │
 └────────────┴───────────────────────────────────────────┘
 ```
+
+Columns can be added to the standard columns:
+```shell
+octl iaas vm list --columns +DNS:PrivateDnsName
+```
+
+Column content is defined with the [expr language](https://expr-lang.org/docs/language-definition). To display a tag value:
+```shell
+octl iaas vm list --columns "+tag:find(Tags, #?.Key == \"Name\")?.Value"
+```
+
 
 ### API access
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,7 +74,7 @@ func init() {
 	rootCmd.PersistentFlags().String("config", "", fmt.Sprintf("Path of profile file (by default, %q)", path))
 	rootCmd.PersistentFlags().String("profile", "", fmt.Sprintf("Profile to use in profile file (by default, %q)", profile.DefaultProfile))
 	rootCmd.PersistentFlags().String("template", "", "JSON template for query body")
-	rootCmd.PersistentFlags().StringP("columns", "c", "", "columns to display")
+	rootCmd.PersistentFlags().StringP("columns", "c", "", "columns to display - [+]title:content|title:content")
 	rootCmd.PersistentFlags().StringP("output", "o", "", "output format (raw, json, yaml, table, none)")
 	rootCmd.PersistentFlags().Bool("no-upgrade", false, "do not check for new versions")
 	rootCmd.PersistentFlags().BoolP("yes", "y", false, "answer yes to all prompts")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,7 +45,7 @@ func (c *Column) Get(v any) (any, error) {
 type Columns []Column
 
 func ParseColumns(s string) Columns {
-	ss := strings.Split(s, ",")
+	ss := strings.Split(s, "|")
 	cs := make(Columns, 0, len(ss))
 	for _, s := range ss {
 		title, content, found := strings.Cut(s, ":")

--- a/pkg/output/flags.go
+++ b/pkg/output/flags.go
@@ -30,7 +30,13 @@ func NewFromFlags(fs *pflag.FlagSet, c config.Call, e config.Entity) (Output, er
 		var cols config.Columns
 		fcols, _ := fs.GetString("columns")
 		if fcols != "" {
-			cols = config.ParseColumns(fcols)
+			add := strings.HasPrefix(fcols, "+")
+			pfcols := config.ParseColumns(strings.TrimPrefix(fcols, "+"))
+			if add {
+				cols = append(slices.Clone(e.Columns), pfcols...)
+			} else {
+				cols = pfcols
+			}
 		} else {
 			cols = slices.Clone(e.Columns)
 		}


### PR DESCRIPTION
## Description

Columns can be added to the standard columns:
```shell
octl iaas vm list --columns +DNS:PrivateDnsName
```

The field separator in columns definition has been changed from `,` to `|` to simplify parsing:
```shell
octl iaas vm list --columns "ID:VmId|DNS:PrivateDnsName"
```

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
