### PR TITLE
🐛 fix: single responses were converted to lists

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -30,6 +30,9 @@ func (o *Paginated) Output(ctx context.Context, fetch read.FetchPage) error {
 	if found {
 		return errRes.Error
 	}
+	if len(res) == 1 && res[0].SingleEntry {
+		return o.Format.Format(ctx, res[0].Ok)
+	}
 	return o.Format.Format(ctx, lo.Map(res, func(r result.Result, _ int) any { return r.Ok }))
 }
 

--- a/pkg/output/read/paginated.go
+++ b/pkg/output/read/paginated.go
@@ -42,7 +42,7 @@ func (p *Paginated) Read(ctx context.Context, fetch FetchPage) iter.Seq[result.R
 			}
 			if len(vres) < 2 {
 				debug.Println("not enough result")
-				_ = yield(result.Result{})
+				_ = yield(result.Result{SingleEntry: true})
 				return
 			}
 			res := reflect.Indirect(vres[0])
@@ -52,7 +52,7 @@ func (p *Paginated) Read(ctx context.Context, fetch FetchPage) iter.Seq[result.R
 			}
 			if content.Kind() != reflect.Slice {
 				debug.Println("not a slice")
-				_ = yield(result.Result{Ok: content.Interface()})
+				_ = yield(result.Result{Ok: content.Interface(), SingleEntry: true})
 				return
 			}
 			for i := range content.Len() {

--- a/pkg/output/read/raw.go
+++ b/pkg/output/read/raw.go
@@ -28,11 +28,11 @@ func (p *Raw) Read(ctx context.Context, fetch FetchPage) iter.Seq[result.Result]
 			_ = yield(result.Result{Error: err})
 			return
 		}
-		if len(vres) == 0 {
-			_ = yield(result.Result{})
+		if len(vres) < 2 {
+			_ = yield(result.Result{SingleEntry: true})
 			return
 		}
-		_ = yield(result.Result{Ok: vres[0].Interface()})
+		_ = yield(result.Result{Ok: vres[0].Interface(), SingleEntry: true})
 	}
 }
 

--- a/pkg/output/result/result.go
+++ b/pkg/output/result/result.go
@@ -1,6 +1,7 @@
 package result
 
 type Result struct {
-	Ok    any
-	Error error
+	SingleEntry bool
+	Ok          any
+	Error       error
 }


### PR DESCRIPTION
## Description

All octl results were converted to lists:
```shell
octl iaas vol create --subregion-name eu-west-2a --size 4 -o json
⬆️ New version v0.0.9 detected - call octl update to update
Resolving alias to [octl iaas api CreateVolume --output=json --Size=4 --SubregionName=eu-west-2a]
[
  {
    "CreationDate": "2026-02-19T10:55:38.388Z",
    "Iops": 0,
    "LinkedVolumes": [],
    "Size": 4,
    "State": "creating",
    "SubregionName": "eu-west-2a",
    "Tags": [],
    "TaskId": null,
    "VolumeId": "vol-797301e8",
    "VolumeType": "standard"
  }
]
```

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
