### PR TITLE
💩 poop: hardcode a pagination limit to avoid infinite loops

### DIFF
--- a/pkg/output/read/paginated.go
+++ b/pkg/output/read/paginated.go
@@ -15,6 +15,8 @@ import (
 	"github.com/outscale/octl/pkg/output/result"
 )
 
+const MaxPages = 20
+
 type Paginated struct {
 	contentField string
 }
@@ -30,7 +32,7 @@ func (p *Paginated) Read(ctx context.Context, fetch FetchPage) iter.Seq[result.R
 	return func(yield func(result.Result) bool) {
 		fetch := fetch
 		idx := 0
-		for {
+		for range MaxPages {
 			vres := fetch.Call(ctx)
 			if len(vres) == 0 {
 				_ = yield(result.Result{Error: errors.New("no result from call")})


### PR DESCRIPTION
## Description

`osc iaas apilog list` tries to load all logs before displaying them.

As a temporary fix to avoid too many API calls and a potential OOM, a page limit is added.

A better alternative needs to be coded.

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
