### PR TITLE
🐛 fix(profile): fix profile loading priority

### DIFF
--- a/cmd/iaas_test.go
+++ b/cmd/iaas_test.go
@@ -158,13 +158,14 @@ func TestIAASCRUD(t *testing.T) {
 		volID := resp.VolumeId
 
 		_ = run(t, []string{"iaas", "vol", "update", volID, "--size", "8"}, nil)
-		ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
 		defer cancel()
 	LOOPWAIT:
 		for {
 			select {
 			case <-ctx.Done():
 				t.Error("timeout")
+				t.FailNow()
 			default:
 				var resp []osc.Volume
 				runJSON(t, []string{"iaas", "vol", "desc", volID, "-o", "json"}, nil, &resp)
@@ -172,6 +173,7 @@ func TestIAASCRUD(t *testing.T) {
 				if resp[0].Size == 8 {
 					break LOOPWAIT
 				}
+				time.Sleep(10 * time.Second)
 			}
 		}
 

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -34,6 +34,12 @@ var profileListCmd = &cobra.Command{
 	Run:   listProfiles,
 }
 
+var profileCurrentCmd = &cobra.Command{
+	Use:   "current",
+	Short: "Display the profile used based on flags/env",
+	Run:   currentProfile,
+}
+
 var profileAddCmd = &cobra.Command{
 	Use:   "add name",
 	Short: "Add a profile to a config file",
@@ -58,6 +64,7 @@ func init() {
 	profileCmd.AddCommand(profileListCmd)
 	profileCmd.AddCommand(profileAddCmd)
 	profileCmd.AddCommand(profileUseCmd)
+	profileCmd.AddCommand(profileCurrentCmd)
 	profileCmd.AddCommand(profileDeleteCmd)
 
 	profileAddCmd.Flags().String("ak", "", "Access Key")
@@ -82,6 +89,9 @@ func configPath(cmd *cobra.Command) string {
 	path, _ := cmd.Flags().GetString("config")
 	if path == "" {
 		path = os.Getenv("OSC_CONFIG_FILE")
+	}
+	if path == "" {
+		path, _ = profile.DefaultConfigPath()
 	}
 	return path
 }
@@ -113,6 +123,15 @@ func listProfiles(cmd *cobra.Command, _ []string) {
 			return cmp.Compare(a.Name, b.Name)
 		})
 	_ = out.Format(cmd.Context(), lst)
+}
+
+func currentProfile(cmd *cobra.Command, _ []string) {
+	out, _, err := output.NewFromFlags(cmd.Flags(), "yaml", "", profileColumns, false, true)
+	if err != nil {
+		messages.ExitErr(err)
+	}
+	p := loadProfile(cmd)
+	_ = out.Format(cmd.Context(), p)
 }
 
 func addProfile(cmd *cobra.Command, args []string) {
@@ -161,13 +180,17 @@ func addProfile(cmd *cobra.Command, args []string) {
 	if region == "" {
 		messages.Exit(1, "Region is required")
 	}
+	def, _ := cmd.Flags().GetBool("default")
 	newProfile := profile.Profile{
 		AccessKey: ak,
 		SecretKey: sk,
 		Region:    region,
+		Default:   def,
 	}
-
 	cf.Profiles[name] = newProfile
+	if def {
+		_ = cf.SetDefault(name)
+	}
 	err = cf.Save()
 	if err != nil {
 		messages.ExitErr(err)

--- a/cmd/profile_test.go
+++ b/cmd/profile_test.go
@@ -122,3 +122,64 @@ func TestProfileSetDefault(t *testing.T) {
 		assert.False(t, lst[1].(map[string]any)["Default"].(bool))
 	})
 }
+
+func TestProfilePriority(t *testing.T) {
+	_ = run(t, []string{"profile", "add", "test_priority", "--ak", "profile_ak", "--sk", "profile_sk", "--region", "profile_region", "--default"}, nil)
+	defer func() {
+		_ = run(t, []string{"profile", "del", "test_priority"}, nil)
+	}()
+	t.Setenv("OSC_ACCESS_KEY", "env_ak")
+	t.Setenv("OSC_SECRET_KEY", "env_sk")
+	t.Setenv("OSC_REGION", "env_region")
+	cfg, err := profile.DefaultConfigPath()
+	require.NoError(t, err)
+	t.Run("By default, the env is loaded", func(t *testing.T) {
+		var p profile.Profile
+		runJSON(t, []string{"profile", "current", "-o", "json"}, nil, &p)
+		assert.Equal(t, "env_ak", p.AccessKey)
+		assert.Equal(t, "env_sk", p.SecretKey)
+		assert.Equal(t, "env_region", p.Region)
+	})
+	t.Run("If --profile is set, profile is loaded", func(t *testing.T) {
+		var p profile.Profile
+		runJSON(t, []string{"profile", "current", "-o", "json", "--profile", "test_priority"}, nil, &p)
+		assert.Equal(t, "profile_ak", p.AccessKey)
+		assert.Equal(t, "profile_sk", p.SecretKey)
+		assert.Equal(t, "profile_region", p.Region)
+	})
+	t.Run("If --config is set, profile is loaded", func(t *testing.T) {
+		var p profile.Profile
+		runJSON(t, []string{"profile", "current", "-o", "json", "--config", cfg}, nil, &p)
+		assert.Equal(t, "profile_ak", p.AccessKey)
+		assert.Equal(t, "profile_sk", p.SecretKey)
+		assert.Equal(t, "profile_region", p.Region)
+	})
+	t.Run("If --config and --profile are set, profile is loaded", func(t *testing.T) {
+		var p profile.Profile
+		runJSON(t, []string{"profile", "current", "-o", "json", "--profile", "test_priority", "--config", cfg}, nil, &p)
+		assert.Equal(t, "profile_ak", p.AccessKey)
+		assert.Equal(t, "profile_sk", p.SecretKey)
+		assert.Equal(t, "profile_region", p.Region)
+	})
+	t.Run("An alternate config file can be used", func(t *testing.T) {
+		cfg := filepath.Join(t.TempDir(), "priority.json")
+		cf := &profile.ConfigFile{
+			Path: cfg,
+			Profiles: map[string]profile.Profile{
+				"foo": {
+					AccessKey: "priority_ak",
+					SecretKey: "priority_sk",
+					Region:    "priority_region",
+					Default:   true,
+				},
+			},
+		}
+		err := cf.Save()
+		require.NoError(t, err)
+		var p profile.Profile
+		runJSON(t, []string{"profile", "current", "-o", "json", "--config", cfg}, nil, &p)
+		assert.Equal(t, "priority_ak", p.AccessKey)
+		assert.Equal(t, "priority_sk", p.SecretKey)
+		assert.Equal(t, "priority_region", p.Region)
+	})
+}

--- a/cmd/sdk.go
+++ b/cmd/sdk.go
@@ -13,7 +13,11 @@ import (
 func loadProfile(cmd *cobra.Command) *profile.Profile {
 	path, _ := cmd.Flags().GetString("config")
 	prof, _ := cmd.Flags().GetString("profile")
-	p, err := profile.New(profile.FromFile(prof, path), profile.FromEnv())
+	var opts []profile.Option
+	if prof != "" || path != "" {
+		opts = []profile.Option{profile.FromFile(prof, path), profile.MergeWith(profile.FromEnv())}
+	}
+	p, err := profile.New(opts...)
 	if err != nil {
 		messages.ExitErr(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/minio/selfupdate v0.6.0
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037
 	github.com/outscale/goutils/sdk v0.0.0-20260127143749-d95db5597c97
-	github.com/outscale/osc-sdk-go/v3 v3.0.0-beta.4.0.20260220134519-ac4f9731735f
+	github.com/outscale/osc-sdk-go/v3 v3.0.0-beta.4.0.20260223140935-69294487017e
 	github.com/samber/lo v1.52.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 h1:bQx3WeLcUWy+RletI
 github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/outscale/goutils/sdk v0.0.0-20260127143749-d95db5597c97 h1:1sgUIBGpxKqklrUtdjcvatnBd5mEbcZ3CFi+5FvfpsQ=
 github.com/outscale/goutils/sdk v0.0.0-20260127143749-d95db5597c97/go.mod h1:/svrKoWyNM1dr1yH2GQeefqUM/0YUhcsBwrCzg8nYoo=
-github.com/outscale/osc-sdk-go/v3 v3.0.0-beta.4.0.20260220134519-ac4f9731735f h1:adaB97fdCBO4gfToKd+QsZDAt9U4CSBHXCKE9CIeoOw=
-github.com/outscale/osc-sdk-go/v3 v3.0.0-beta.4.0.20260220134519-ac4f9731735f/go.mod h1:lHUAK++U7ud9q15AE5262liA3q46NgMyypL1yOaxI6U=
+github.com/outscale/osc-sdk-go/v3 v3.0.0-beta.4.0.20260223140935-69294487017e h1:m8TABYuruGhkxMONOTrFhx7TGgmHKekXVloF4RA9Cwc=
+github.com/outscale/osc-sdk-go/v3 v3.0.0-beta.4.0.20260223140935-69294487017e/go.mod h1:lHUAK++U7ud9q15AE5262liA3q46NgMyypL1yOaxI6U=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
## Description

The profile file was always loaded before env.

This PR fixes the priority (env > file unless `--profile` or `--config` is set), add adds a `octl profile current` to display the profile loaded by octl using the specified flags/env.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
