### PR TITLE
✨ feat(flags): add file based flags (keys, policies)

### DIFF
--- a/cmd/iaas_test.go
+++ b/cmd/iaas_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -165,6 +166,7 @@ func TestIAASCRUD(t *testing.T) {
 			select {
 			case <-ctx.Done():
 				t.Error("timeout")
+				t.FailNow()
 			default:
 				var resp []osc.Volume
 				runJSON(t, []string{"iaas", "vol", "desc", volID, "-o", "json"}, nil, &resp)
@@ -172,6 +174,7 @@ func TestIAASCRUD(t *testing.T) {
 				if resp[0].Size == 8 {
 					break LOOPWAIT
 				}
+				time.Sleep(10 * time.Second)
 			}
 		}
 
@@ -213,4 +216,14 @@ func TestIAASCRUD(t *testing.T) {
 			assert.Equal(t, osc.VolumeStateDeleting, vol.State)
 		}
 	})
+}
+
+func TestBase64(t *testing.T) {
+	key := filepath.Join(t.TempDir(), "test.pem")
+	err := exec.CommandContext(t.Context(), "ssh-keygen", "-t", "rsa", "-b", "4096", "-f", key).Run()
+	require.NoError(t, err)
+	var resp osc.KeypairCreated
+	runJSON(t, []string{"iaas", "keypair", "create", "--name", "test-b64", "--public-key", key + ".pub", "-o", "json", "-v"}, nil, &resp)
+	require.NotNil(t, resp.KeypairName)
+	assert.Equal(t, "test-b64", *resp.KeypairName)
 }

--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -13,6 +13,7 @@ import (
 	"github.com/outscale/octl/pkg/builder/openapi"
 	"github.com/outscale/octl/pkg/config"
 	"github.com/outscale/octl/pkg/debug"
+	"github.com/outscale/octl/pkg/flags"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 )
@@ -64,12 +65,22 @@ func (b *Builder[T]) Build(rootCmd *cobra.Command) {
 		if callCmd == nil {
 			continue
 		}
-		debug.Println(a.Entity, a.Use)
 		for _, f := range a.Flags {
 			flag := callCmd.Flags().Lookup(f.AliasTo)
 			if flag != nil {
 				nflag := *flag
 				nflag.Name = f.Name
+				switch f.Type {
+				case "base64File":
+					debug.Println("overriding type for flag", f.Name, "to", f.Type)
+					nflag.Value = flags.NewBase64FileValue()
+				case "file":
+					debug.Println("overriding type for flag", f.Name, "to", f.Type)
+					nflag.Value = flags.NewFileValue()
+				}
+				if f.Usage != "" {
+					nflag.Usage = f.Usage
+				}
 				cmd.Flags().AddFlag(&nflag)
 
 				completion, found := callCmd.GetFlagCompletionFunc(f.AliasTo)
@@ -78,6 +89,10 @@ func (b *Builder[T]) Build(rootCmd *cobra.Command) {
 				}
 				if f.Required {
 					_ = cmd.MarkFlagRequired(nflag.Name)
+				}
+				switch f.Type {
+				case "base64File", "file":
+					_ = cmd.MarkFlagFilename(f.Name)
 				}
 			}
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,6 +87,8 @@ type Flag struct {
 	Name     string `yaml:"name"`
 	AliasTo  string `yaml:"alias_to"`
 	Required bool   `yaml:"required,omitempty"`
+	Type     string `yaml:"type,omitempty"`
+	Usage    string `yaml:"usage,omitempty"`
 }
 
 type Prompt struct {

--- a/pkg/config/defaults_iaas.yaml
+++ b/pkg/config/defaults_iaas.yaml
@@ -3378,6 +3378,8 @@ aliases:
     required: true
   - name: public-key
     alias_to: PublicKey
+    type: base64File
+    usage: The file storing the public key to import in your account, if you are importing an existing keypair.
 - entity: listenerrule
   group: listenerrule
   use: create
@@ -3603,6 +3605,8 @@ aliases:
   - name: document
     alias_to: Document
     required: true
+    type: file
+    usage: The file storing the policy document, corresponding to a JSON string that contains the policy.
   - name: path
     alias_to: Path
   - name: name
@@ -3621,6 +3625,8 @@ aliases:
   - name: document
     alias_to: Document
     required: true
+    type: file
+    usage: The file storing the policy document, corresponding to a JSON string that contains the policy.
   - name: policy-orn
     alias_to: PolicyOrn
     required: true
@@ -4041,6 +4047,8 @@ aliases:
     alias_to: TpmEnabled
   - name: user-data
     alias_to: UserData
+    type: base64File
+    usage: The file storing the data or script used to add a specific configuration to the VM (max size 500 KiB).
   - name: initiated-shutdown-behavior
     alias_to: VmInitiatedShutdownBehavior
   - name: type
@@ -5187,6 +5195,8 @@ aliases:
     alias_to: SecurityGroupIds
   - name: user-data
     alias_to: UserData
+    type: base64File
+    usage: The file storing the data or script used to add a specific configuration to the VM (max size 500 KiB).
   - name: initiated-shutdown-behavior
     alias_to: VmInitiatedShutdownBehavior
   - name: type

--- a/pkg/config/generate/iaas/builder/builder.go
+++ b/pkg/config/generate/iaas/builder/builder.go
@@ -32,6 +32,25 @@ var priorityFields = []string{
 	"Email",
 }
 
+var flagOverrides = map[string]config.Flag{
+	"public-key": {
+		Type:  "base64File",
+		Usage: "The file storing the public key to import in your account, if you are importing an existing keypair.",
+	},
+	"user-data": {
+		Type:  "base64File",
+		Usage: "The file storing the data or script used to add a specific configuration to the VM (max size 500 KiB).",
+	},
+	"policy-document": {
+		Type:  "file",
+		Usage: "The file storing the policy document, corresponding to a JSON string that contains the policy.",
+	},
+	"document": {
+		Type:  "file",
+		Usage: "The file storing the policy document, corresponding to a JSON string that contains the policy.",
+	},
+}
+
 var ErrCantBuild = errors.New("cannot build")
 
 type Builder struct {
@@ -91,7 +110,10 @@ func (b *Builder) Build() error {
 	case strings.HasPrefix(b.m.Name, "Delete"):
 		err = b.buildDeleteAlias()
 	case strings.HasPrefix(b.m.Name, "Update"):
-		err = b.buildUpdateAlias()
+		err = b.buildCall()
+		if err == nil {
+			err = b.buildUpdateAlias()
+		}
 	case strings.HasPrefix(b.m.Name, "Create"):
 		err = b.buildCall()
 		if err == nil {
@@ -210,11 +232,16 @@ func (b *Builder) buildFlags(t reflect.Type, prefix string, ignore []string) con
 		if _, found := cfs.Get(stripped); !found {
 			flag = stripped
 		}
-		cfs = append(cfs, config.Flag{
+		cf := flagOverrides[f.Name]
+		err := mergo.Merge(&cf, config.Flag{
 			Name:     flag,
 			AliasTo:  f.FieldPath,
 			Required: f.Required,
 		})
+		if err != nil {
+			panic(err)
+		}
+		cfs = append(cfs, cf)
 	}
 	return cfs
 }

--- a/pkg/flags/base64.go
+++ b/pkg/flags/base64.go
@@ -1,0 +1,38 @@
+package flags
+
+import (
+	"encoding/base64"
+	"os"
+)
+
+// Base64FileValue adapts File.File for use as a flag.
+type Base64FileValue struct {
+	content []byte
+}
+
+func NewBase64FileValue() *Base64FileValue {
+	return &Base64FileValue{}
+}
+
+// Set sets the value based on a file content.
+func (v *Base64FileValue) Set(s string) error {
+	buf, err := os.ReadFile(s)
+	if err != nil {
+		return err
+	}
+	v.content = buf
+	return nil
+}
+
+// Type name for File.File flags.
+func (v *Base64FileValue) Type() string {
+	return "base64File"
+}
+
+func (v *Base64FileValue) String() string {
+	return base64.StdEncoding.EncodeToString(v.content)
+}
+
+func (v *Base64FileValue) Value() (string, bool) {
+	return v.String(), true
+}

--- a/pkg/flags/base64_test.go
+++ b/pkg/flags/base64_test.go
@@ -1,0 +1,26 @@
+package flags_test
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/outscale/octl/pkg/flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBase64FileValue(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "filevalue.test")
+	err := os.WriteFile(path, []byte("foo"), 0600)
+	require.NoError(t, err)
+	v := flags.NewBase64FileValue()
+	err = v.Set(path)
+	require.NoError(t, err)
+	content, ok := v.Value()
+	assert.True(t, ok)
+	decoded, err := base64.StdEncoding.DecodeString(content)
+	require.NoError(t, err)
+	assert.Equal(t, "foo", string(decoded))
+}

--- a/pkg/flags/file.go
+++ b/pkg/flags/file.go
@@ -1,0 +1,37 @@
+package flags
+
+import (
+	"os"
+)
+
+// FileValue adapts File.File for use as a flag.
+type FileValue struct {
+	content []byte
+}
+
+func NewFileValue() *FileValue {
+	return &FileValue{}
+}
+
+// Set sets the value based on a file content.
+func (v *FileValue) Set(s string) error {
+	buf, err := os.ReadFile(s)
+	if err != nil {
+		return err
+	}
+	v.content = buf
+	return nil
+}
+
+// Type name for File.File flags.
+func (v *FileValue) Type() string {
+	return "File"
+}
+
+func (v *FileValue) String() string {
+	return string(v.content)
+}
+
+func (v *FileValue) Value() (string, bool) {
+	return v.String(), true
+}

--- a/pkg/flags/file_test.go
+++ b/pkg/flags/file_test.go
@@ -1,0 +1,23 @@
+package flags_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/outscale/octl/pkg/flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileValue(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "filevalue.test")
+	err := os.WriteFile(path, []byte("foo"), 0600)
+	require.NoError(t, err)
+	v := flags.NewFileValue()
+	err = v.Set(path)
+	require.NoError(t, err)
+	content, ok := v.Value()
+	assert.True(t, ok)
+	assert.Equal(t, "foo", content)
+}


### PR DESCRIPTION
## Description

Allow sourcing the content of a flag from a file (CreateKeypair.PublicKey, CreatePolicy.Document, CreateVms.UserData).

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet


## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
