### PR TITLE
🐛 fix(update): no update if already the latest version

### DIFF
--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -16,6 +16,9 @@ import (
 	"github.com/google/go-github/v82/github"
 	"github.com/minio/selfupdate"
 	"github.com/outscale/octl/pkg/debug"
+	"github.com/outscale/octl/pkg/messages"
+	"github.com/outscale/octl/pkg/version"
+	"golang.org/x/mod/semver"
 )
 
 func latestRelease(ctx context.Context) (*github.RepositoryRelease, error) {
@@ -36,7 +39,7 @@ func LatestRelease(ctx context.Context) (string, error) {
 	if rel == nil || err != nil {
 		return "", err
 	}
-	return *rel.TagName, nil
+	return rel.GetTagName(), nil
 }
 
 func Update(ctx context.Context) error {
@@ -47,6 +50,11 @@ func Update(ctx context.Context) error {
 	if rel == nil {
 		return errors.New("no new version found")
 	}
+	if semver.Compare(version.Version, rel.GetTagName()) >= 0 {
+		messages.Warn("Already using the latest version")
+		return nil
+	}
+
 	debug.Println("OS, arch:", runtime.GOOS, runtime.GOARCH)
 	suffix := runtime.GOOS + "_"
 	switch runtime.GOARCH {


### PR DESCRIPTION
## Description

`octl update` now stops updating if octl is already up to date.

Fixes: #47

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
