### PR TITLE
♻️ refacto(kube): refactored kubectl args & flags

### DIFF
--- a/cmd/kube.go
+++ b/cmd/kube.go
@@ -37,8 +37,6 @@ func init() {
 			!strings.HasSuffix(m.Name, "WithBody")
 	}, kube)
 	b.Build(oksCmd, nil)
-
-	oksCmd.AddCommand(kubectlCmd)
 }
 
 func kube(cmd *cobra.Command, args []string) {

--- a/cmd/kube_kubectl.go
+++ b/cmd/kube_kubectl.go
@@ -20,11 +20,10 @@ import (
 )
 
 var kubectlCmd = &cobra.Command{
-	Use: "kubectl cluster_name [kubectl_args] [kubectl_flags]",
+	Use: "kubectl [octl_flags] -- kubectl_args [kubectl_flags]",
 	Long: `Launch kubectl commands on a cluster.
-Example: octl kube kubectl cluster_name get pods -o wide`,
-	DisableFlagParsing: true,
-	Run:                kubectl,
+Example: octl kube kubectl --cluster cluster_name -- get pods -o wide`,
+	Run: kubectl,
 }
 
 func kubectl(cmd *cobra.Command, args []string) {
@@ -33,15 +32,15 @@ func kubectl(cmd *cobra.Command, args []string) {
 	if err != nil {
 		messages.ExitErr(err)
 	}
-	cluster := args[0]
+	cluster, _ := cmd.Flags().GetString("cluster")
 	kubeconfig, err := getKubeconfig(cmd.Context(), cluster, cl)
 	if err != nil {
 		messages.ExitErr(err)
 	}
-	newArgs := make([]string, 1, len(args)+2)
+	newArgs := make([]string, 1, len(args)+3)
 	newArgs[0] = "kubectl"
 	newArgs = append(newArgs, "--kubeconfig", kubeconfig)
-	newArgs = append(newArgs, args[1:]...)
+	newArgs = append(newArgs, args...)
 	os.Args = newArgs
 	debug.Println("new args", newArgs)
 	kubectlCmd := kubecmd.NewDefaultKubectlCommand()
@@ -117,4 +116,10 @@ func refreshKubeconfig(ctx context.Context, id, path string, cl *oks.Client) err
 		return fmt.Errorf("fetch Kubeconfig: %w", err)
 	}
 	return os.WriteFile(path, []byte(res.Cluster.Data.Kubeconfig), 0o600)
+}
+
+func init() {
+	oksCmd.AddCommand(kubectlCmd)
+	kubectlCmd.Flags().String("cluster", "", "Name or ID of cluster")
+	_ = kubectlCmd.MarkFlagRequired("cluster")
 }

--- a/cmd/kube_test.go
+++ b/cmd/kube_test.go
@@ -33,7 +33,7 @@ func TestKube(t *testing.T) {
 	t.Log("Kubectl can be run")
 	{
 		var resp corev1.NodeList
-		runJSON(t, []string{"kube", "kubectl", cluster, "get", "nodes", "-o", "json"}, nil, &resp)
+		runJSON(t, []string{"kube", "kubectl", "--cluster", cluster, "--", "get", "nodes", "-o", "json"}, nil, &resp)
 		assert.Equal(t, "List", resp.Kind)
 	}
 }

--- a/docs/reference/octl_kube_kubectl.md
+++ b/docs/reference/octl_kube_kubectl.md
@@ -5,16 +5,17 @@
 ### Synopsis
 
 Launch kubectl commands on a cluster.
-Example: octl kube kubectl cluster_name get pods -o wide
+Example: octl kube kubectl --cluster cluster_name -- get pods -o wide
 
 ```
-octl kube kubectl cluster_name [kubectl_args] [kubectl_flags] [flags]
+octl kube kubectl [octl_flags] -- kubectl_args [kubectl_flags] [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for kubectl
+      --cluster string   Name or ID of cluster
+  -h, --help             help for kubectl
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## Description

The `octl kube kubectl` was problematic:
* it was not coherent with the other commands - cluster should be a flag, not an arg,
* the global flags were not parsed, forbidding the use of --config/--profile.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
