### PR TITLE
🐛 fix(profile): fix profile ls output

### DIFF
--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -30,9 +30,10 @@ var profileCmd = &cobra.Command{
 }
 
 var profileListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "Lists all profiles from a config file",
-	Run:   listProfiles,
+	Use:     "list",
+	Short:   "Lists all profiles from a config file",
+	Aliases: []string{"ls"},
+	Run:     listProfiles,
 }
 
 var profileCurrentCmd = &cobra.Command{
@@ -82,12 +83,12 @@ func init() {
 }
 
 type profileEntry struct {
-	Name    string
-	Default bool
-	profile.Profile
+	Name            string `json:"name"`
+	Default         bool   `json:"default,omitempty"`
+	profile.Profile `json:",inline"`
 }
 
-var profileColumns = config.Columns{{Title: "Name", Content: "Name"}, {Title: "Region", Content: "Region"}, {Title: "Default", Content: "Default"}}
+var profileColumns = config.Columns{{Title: "Name", Content: ".name"}, {Title: "Region", Content: ".region"}, {Title: "Default", Content: ".default"}}
 
 func configPath(cmd *cobra.Command) string {
 	path, _ := cmd.Flags().GetString("config")

--- a/cmd/profile_test.go
+++ b/cmd/profile_test.go
@@ -79,10 +79,10 @@ func TestProfileList(t *testing.T) {
 		var lst []any
 		runJSON(t, []string{"profile", "list", "--config", file, "-o", "json"}, nil, &lst)
 		require.Len(t, lst, 2)
-		assert.Equal(t, "bar", lst[0].(map[string]any)["Name"])
-		assert.False(t, lst[0].(map[string]any)["Default"].(bool))
-		assert.Equal(t, "foo", lst[1].(map[string]any)["Name"])
-		assert.True(t, lst[1].(map[string]any)["Default"].(bool))
+		assert.Equal(t, "bar", lst[0].(map[string]any)["name"])
+		assert.Empty(t, lst[0].(map[string]any)["default"])
+		assert.Equal(t, "foo", lst[1].(map[string]any)["name"])
+		assert.Equal(t, true, lst[1].(map[string]any)["default"])
 	})
 	t.Run("Profiles can be listed, even if no default profile is configured", func(t *testing.T) {
 		file := filepath.Join(t.TempDir(), "list.json")
@@ -97,6 +97,24 @@ func TestProfileList(t *testing.T) {
 		var lst []any
 		runJSON(t, []string{"profile", "list", "--config", file, "-o", "json"}, nil, &lst)
 		require.Len(t, lst, 1)
+	})
+	t.Run("Table output works", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "list.json")
+		cf := &profile.ConfigFile{
+			Path: file,
+			Profiles: map[string]profile.Profile{
+				"foo": {
+					Default: true,
+					Region:  "eu-west-2",
+				},
+			},
+		}
+		err := cf.Save()
+		require.NoError(t, err)
+		res := run(t, []string{"profile", "list", "--config", file}, nil)
+		assert.Contains(t, string(res), "foo")
+		assert.Contains(t, string(res), "true")
+		assert.Contains(t, string(res), "eu-west-2")
 	})
 }
 
@@ -116,10 +134,10 @@ func TestProfileSetDefault(t *testing.T) {
 		var lst []any
 		runJSON(t, []string{"profile", "list", "--config", file, "-o", "json"}, nil, &lst)
 		require.Len(t, lst, 2)
-		assert.Equal(t, "bar", lst[0].(map[string]any)["Name"])
-		assert.True(t, lst[0].(map[string]any)["Default"].(bool))
-		assert.Equal(t, "foo", lst[1].(map[string]any)["Name"])
-		assert.False(t, lst[1].(map[string]any)["Default"].(bool))
+		assert.Equal(t, "bar", lst[0].(map[string]any)["name"])
+		assert.Equal(t, true, lst[0].(map[string]any)["default"])
+		assert.Equal(t, "foo", lst[1].(map[string]any)["name"])
+		assert.Empty(t, lst[1].(map[string]any)["default"])
 	})
 }
 


### PR DESCRIPTION
## Description

`octl profile list` generated an empty table. This PR fixes the columns definition.

It also adds the missing `ls` alias.

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [x] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
