### PR TITLE
✨ feat(kube): add command to create CCM/CSI secrets

### DIFF
--- a/cmd/kube_secret.go
+++ b/cmd/kube_secret.go
@@ -1,0 +1,72 @@
+/*
+SPDX-FileCopyrightText: 2026 Outscale SAS <opensource@outscale.com>
+
+SPDX-License-Identifier: BSD-3-Clause
+*/
+package cmd
+
+import (
+	"os"
+
+	"github.com/outscale/octl/pkg/markdown"
+	"github.com/outscale/octl/pkg/output/format"
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var secretLongUse = "Create secret for CCM/CSI driver/Cluster-API provider deployments using the selected AK/SK.\n\n" +
+	"CCM:\n" +
+	"```shell\n" +
+	"octl kube secret --name osc-secret | kubectl apply -f -\n" +
+	"```\n" +
+	"CSI driver:\n" +
+	"```shell\n" +
+	"octl kube secret --name osc-csi-bsu | kubectl apply -f -\n" +
+	"```\n" +
+	"Cluster-API:\n" +
+	"```shell\n" +
+	"octl kube secret --name cluster-api-provider-outscale --namespace cluster-api-provider-outscale-system | kubectl apply -f -\n" +
+	"```\n"
+
+var (
+	secretLongUseRendered = lo.Must(markdown.NewRenderer().Render(secretLongUse))
+	secretCmd             = &cobra.Command{
+		Use:   "secret",
+		Long:  secretLongUseRendered,
+		Short: "Create secret for CCM or CSI driver deployment",
+		Args:  cobra.NoArgs,
+		Run:   exportProfile,
+	}
+)
+
+func init() {
+	oksCmd.AddCommand(secretCmd)
+	secretCmd.Flags().String("name", "", "name of secret")
+	secretCmd.Flags().String("namespace", "kube-system", "namespace of secret")
+	_ = secretCmd.MarkFlagRequired("name")
+}
+
+func exportProfile(cmd *cobra.Command, args []string) {
+	p := loadProfile(cmd)
+	ns, _ := cmd.Flags().GetString("namespace")
+	name, _ := cmd.Flags().GetString("name")
+	s := corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Data: map[string][]byte{
+			"access_key": []byte(p.AccessKey),
+			"secret_key": []byte(p.SecretKey),
+			"region":     []byte(p.Region),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	_ = format.YAML{}.Format(cmd.Context(), os.Stdout, s)
+}

--- a/docs/reference/octl_kube_secret.md
+++ b/docs/reference/octl_kube_secret.md
@@ -1,11 +1,35 @@
-## octl kube
+## octl kube secret
 
-OUTSCALE Kubernetes as a Service (OKS) management
+Create secret for CCM or CSI driver deployment
+
+### Synopsis
+
+Create secret for CCM/CSI driver/Cluster-API provider deployments using the selected AK/SK.
+
+CCM:
+```shell
+octl kube secret --name osc-secret | kubectl apply -f -
+```
+CSI driver:
+```shell
+octl kube secret --name osc-csi-bsu | kubectl apply -f -
+```
+Cluster-API:
+```shell
+octl kube secret --name cluster-api-provider-outscale --namespace cluster-api-provider-outscale-system | kubectl apply -f -
+```
+
+
+```
+octl kube secret [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for kube
+  -h, --help               help for secret
+      --name string        name of secret
+      --namespace string   namespace of secret (default "kube-system")
 ```
 
 ### Options inherited from parent commands
@@ -31,13 +55,5 @@ OUTSCALE Kubernetes as a Service (OKS) management
 
 ### SEE ALSO
 
-* [octl](octl.md)	 - A modern CLI for Outscale services
-* [octl kube api](octl_kube_api.md)	 - kube api calls
-* [octl kube cluster](octl_kube_cluster.md)	 - cluster commands
-* [octl kube kubectl](octl_kube_kubectl.md)	 - 
-* [octl kube nodepool](octl_kube_nodepool.md)	 - nodepool commands
-* [octl kube project](octl_kube_project.md)	 - project commands
-* [octl kube publicip](octl_kube_publicip.md)	 - publicip commands
-* [octl kube quota](octl_kube_quota.md)	 - quota commands
-* [octl kube secret](octl_kube_secret.md)	 - Create secret for CCM or CSI driver deployment
+* [octl kube](octl_kube.md)	 - OUTSCALE Kubernetes as a Service (OKS) management
 

--- a/pkg/output/format/yaml.go
+++ b/pkg/output/format/yaml.go
@@ -6,6 +6,7 @@ package format
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
@@ -16,7 +17,11 @@ import (
 type YAML struct{}
 
 func (YAML) Format(ctx context.Context, w io.Writer, v any) error {
-	enc := yaml.NewEncoder(w, yaml.OmitZero(), yaml.UseSingleQuote(true), yaml.Indent(2))
+	enc := yaml.NewEncoder(w, yaml.OmitZero(), yaml.UseSingleQuote(true), yaml.Indent(2), yaml.CustomMarshaler(
+		func(v []byte) ([]byte, error) {
+			return []byte(base64.StdEncoding.EncodeToString(v)), nil
+		},
+	))
 	err := enc.Encode(v)
 	if err != nil {
 		return fmt.Errorf("marshal yaml: %w", err)


### PR DESCRIPTION
## Description

This PR adds the `octl kube secret` command to generate secrets required by the CSI driver/CCM/Cluster-API provider.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
