### PR TITLE
🐛 fix(kube): add missing --project flag on cluster commands

### DIFF
--- a/cmd/kube.go
+++ b/cmd/kube.go
@@ -16,8 +16,10 @@ import (
 	"github.com/outscale/octl/pkg/config"
 	"github.com/outscale/octl/pkg/debug"
 	"github.com/outscale/octl/pkg/messages"
+	"github.com/outscale/octl/pkg/preferences"
 	"github.com/outscale/octl/pkg/runner"
 	"github.com/outscale/osc-sdk-go/v3/pkg/oks"
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 )
 
@@ -29,6 +31,13 @@ var oksCmd = &cobra.Command{
 	Aliases: []string{"oks"},
 }
 
+var projectUseCmd = &cobra.Command{
+	Use:   "use [project_id_or_name]",
+	Short: "Set a default project for cluster commands, reset it without args",
+	Run:   useProject,
+	Args:  cobra.MaximumNArgs(1),
+}
+
 func init() {
 	rootCmd.AddCommand(oksCmd)
 	b := builder.NewBuilder[oks.Client]("kube", "https://docs.outscale.com/oks.html")
@@ -37,6 +46,36 @@ func init() {
 			!strings.HasSuffix(m.Name, "WithBody")
 	}, kube)
 	b.Build(oksCmd, nil)
+
+	// Add --project flag to kube cluster commands
+	clusterCmd, _ := lo.Find(oksCmd.Commands(), func(c *cobra.Command) bool { return c.Name() == "cluster" })
+	clusterCmd.PersistentFlags().String("project", preferences.Preferences.Kube.DefaultProject, "project name")
+
+	// Remap <cluster ls --project name> to <project clusters name>
+	projectCmd, _ := lo.Find(oksCmd.Commands(), func(c *cobra.Command) bool { return c.Name() == "project" })
+	projectClustersCmd, _ := lo.Find(projectCmd.Commands(), func(c *cobra.Command) bool { return c.Name() == "clusters" })
+	clusterListCmd, _ := lo.Find(clusterCmd.Commands(), func(c *cobra.Command) bool { return c.Name() == "list" })
+	runClusterListCmd := clusterListCmd.Run
+	clusterListCmd.Run = func(cmd *cobra.Command, args []string) {
+		project, _ := cmd.Flags().GetString("project")
+		if project != "" {
+			cmd.Flag("project").Changed = false
+			projectClustersCmd.Run(cmd, []string{project})
+		} else {
+			runClusterListCmd(cmd, nil)
+		}
+	}
+
+	// Project use
+	projectCmd.AddCommand(projectUseCmd)
+
+	// Add --project flag to kube api cluster commands
+	apiCmd, _ := lo.Find(oksCmd.Commands(), func(c *cobra.Command) bool { return c.Name() == "api" })
+	lo.ForEach(apiCmd.Commands(), func(c *cobra.Command, _ int) {
+		if strings.HasSuffix(c.Name(), "Cluster") || c.Name() == "GetKubeconfig" {
+			c.Flags().String("project", preferences.Preferences.Kube.DefaultProject, "project name")
+		}
+	})
 }
 
 func kube(cmd *cobra.Command, args []string) {
@@ -67,7 +106,8 @@ func argNameToID(cmd *cobra.Command, args []string, cl *oks.Client) []string {
 	case "GetProject", "DeleteProject", "GetProjectNets", "GetProjectQuotas", "GetProjectPublicIps", "GetProjectSnapshots":
 		args[0], err = projectNameToID(cmd.Context(), args[0], cl)
 	case "GetCluster", "UpdateCluster", "DeleteCluster", "GetKubeconfig":
-		args[0], err = clusterNameToID(cmd.Context(), args[0], cl)
+		project, _ := cmd.Flags().GetString("project")
+		args[0], err = clusterNameToID(cmd.Context(), args[0], project, cl)
 	}
 	if err != nil {
 		messages.ExitErr(err)
@@ -102,18 +142,54 @@ func projectNameToID(ctx context.Context, name string, cl *oks.Client) (string, 
 	}
 }
 
-func clusterNameToID(ctx context.Context, name string, cl *oks.Client) (string, error) {
-	cs, err := cl.ListAllClusters(ctx, &oks.ListAllClustersParams{Name: &name})
+func clusterNameToID(ctx context.Context, name, project string, cl *oks.Client) (string, error) {
+	var (
+		cs  *oks.ClusterResponseList
+		err error
+	)
+	if project != "" {
+		var pid string
+		if _, err := uuid.Parse(project); err == nil {
+			pid = project
+			debug.Println("project is an uuid")
+		} else {
+			pid, err = projectNameToID(ctx, project, cl)
+			if err != nil {
+				return "", err
+			}
+		}
+		cs, err = cl.ListClustersByProjectID(ctx, &oks.ListClustersByProjectIDParams{Name: &name, ProjectId: &pid})
+	} else {
+		cs, err = cl.ListAllClusters(ctx, &oks.ListAllClustersParams{Name: &name})
+	}
 	if err != nil {
 		return "", err
 	}
-	switch len(cs.Clusters) {
+	clusters := cs.Clusters
+	switch len(clusters) {
 	case 0:
 		return "", fmt.Errorf("cluster %q not found", name)
 	case 1:
-		debug.Println("replacing", name, "by", cs.Clusters[0].Id)
-		return cs.Clusters[0].Id, nil
+		debug.Println("replacing", name, "by", clusters[0].Id)
+		return clusters[0].Id, nil
 	default:
 		return "", fmt.Errorf("multiple clusters found with the name %q", name)
+	}
+}
+
+func useProject(c *cobra.Command, args []string) {
+	var def string
+	if len(args) > 0 {
+		def = args[0]
+	}
+	preferences.Preferences.Kube.DefaultProject = def
+	err := preferences.Preferences.Save()
+	if err != nil {
+		messages.ExitErr(err)
+	}
+	if def == "" {
+		messages.Success("The default project has been reset")
+	} else {
+		messages.Success("%q is now the default project for all octl kube commands", def)
 	}
 }

--- a/cmd/kube_helpers_test.go
+++ b/cmd/kube_helpers_test.go
@@ -3,22 +3,42 @@ package cmd_test
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"encoding/json"
 	"testing"
 )
 
-const projectName = "octl-test"
+const (
+	projectName      = "octl-test"
+	emptyProjectName = "octl-test-empty"
+)
 
 // project creates a testing project
 // as project creation is very slow, the project is kept between runs
-func project(t *testing.T) {
+func project(t *testing.T) string {
 	t.Helper()
-
 	_, err := try(t.Context(), []string{"kube", "project", "desc", projectName, "-o", "json"}, nil)
 	if err == nil {
-		return
+		return projectName
 	}
 	_ = run(t, []string{"kube", "project", "create", "--name", projectName}, nil)
 	retryUntil(t, []string{"kube", "project", "desc", projectName, "-o", "json"}, nil, "status", "ready")
+	return projectName
+}
+
+// project creates a testing project without cluster.
+// to avoid quota problems, any existing project (except octl-test) should work.
+// as project creation is very slow, the project is kept between runs
+func projectWithoutCluster(t *testing.T) string {
+	t.Helper()
+	res := run(t, []string{"kube", "project", "ls", "--jq", `select(.name!="` + projectName + `") .name`, "-o", "json"}, nil)
+	var lst []string
+	err := json.Unmarshal(res, &lst)
+	if err == nil && len(lst) > 0 {
+		return lst[0]
+	}
+	_ = run(t, []string{"kube", "project", "create", "--name", emptyProjectName}, nil)
+	retryUntil(t, []string{"kube", "project", "desc", emptyProjectName, "-o", "json"}, nil, "status", "ready")
+	return emptyProjectName
 }
 
 // cluster creates a testing cluster

--- a/cmd/kube_kubeapi.go
+++ b/cmd/kube_kubeapi.go
@@ -20,7 +20,8 @@ func kubeapi(provider string) func(cmd *cobra.Command, args []string) {
 			messages.ExitErr(err)
 		}
 		cluster, _ := cmd.Flags().GetString("cluster")
-		kubeconfig, err := getKubeconfig(cmd.Context(), cluster, cl)
+		project, _ := cmd.Flags().GetString("project")
+		kubeconfig, err := getKubeconfig(cmd.Context(), cluster, project, cl)
 		if err != nil {
 			messages.ExitErr(err)
 		}

--- a/cmd/kube_kubectl.go
+++ b/cmd/kube_kubectl.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/outscale/octl/pkg/debug"
 	"github.com/outscale/octl/pkg/messages"
+	"github.com/outscale/octl/pkg/preferences"
 	"github.com/outscale/osc-sdk-go/v3/pkg/oks"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
@@ -33,7 +34,8 @@ func kubectl(cmd *cobra.Command, args []string) {
 		messages.ExitErr(err)
 	}
 	cluster, _ := cmd.Flags().GetString("cluster")
-	kubeconfig, err := getKubeconfig(cmd.Context(), cluster, cl)
+	project, _ := cmd.Flags().GetString("project")
+	kubeconfig, err := getKubeconfig(cmd.Context(), cluster, project, cl)
 	if err != nil {
 		messages.ExitErr(err)
 	}
@@ -50,8 +52,8 @@ func kubectl(cmd *cobra.Command, args []string) {
 	}
 }
 
-func getKubeconfig(ctx context.Context, cluster string, cl *oks.Client) (string, error) {
-	id, err := clusterNameToID(ctx, cluster, cl)
+func getKubeconfig(ctx context.Context, cluster, project string, cl *oks.Client) (string, error) {
+	id, err := clusterNameToID(ctx, cluster, project, cl)
 	if err != nil {
 		return "", err
 	}
@@ -122,4 +124,5 @@ func init() {
 	oksCmd.AddCommand(kubectlCmd)
 	kubectlCmd.Flags().String("cluster", "", "Name or ID of cluster")
 	_ = kubectlCmd.MarkFlagRequired("cluster")
+	kubectlCmd.Flags().String("project", preferences.Preferences.Kube.DefaultProject, "Name or ID of project")
 }

--- a/cmd/kube_nodepool.go
+++ b/cmd/kube_nodepool.go
@@ -6,6 +6,7 @@ import (
 
 	oksv1beta2 "github.com/outscale/goutils/oks/clientset/typed/oks.dev/v1beta2"
 	"github.com/outscale/octl/pkg/builder"
+	"github.com/outscale/octl/pkg/preferences"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +28,9 @@ func init() {
 	apiCmd, _ := lo.Find(nodepoolCmd.Commands(), func(c *cobra.Command) bool { return c.Name() == "api" })
 	apiCmd.PersistentFlags().String("cluster", "", "Name or ID of cluster")
 	_ = apiCmd.MarkPersistentFlagRequired("cluster")
+	apiCmd.PersistentFlags().String("project", preferences.Preferences.Kube.DefaultProject, "Name or ID of project")
 	// nodepool commands need to be added to the upper level, otherwise we will get kube nodepool nodepool
 	b.Build(oksCmd, apiCmd)
+	clusterCmd, _ := lo.Find(oksCmd.Commands(), func(c *cobra.Command) bool { return c.Name() == "nodepool" })
+	clusterCmd.PersistentFlags().String("project", preferences.Preferences.Kube.DefaultProject, "project name")
 }

--- a/cmd/kube_test.go
+++ b/cmd/kube_test.go
@@ -9,31 +9,85 @@ import (
 )
 
 func TestKube(t *testing.T) {
-	project(t)
+	project := project(t)
+	emptyProject := projectWithoutCluster(t)
 	cluster := cluster(t)
 
-	t.Log("Tags can be set")
-	{
+	t.Run("Projects can be listed", func(t *testing.T) {
+		var resp []oks.Project
+		runJSON(t, []string{"kube", "project", "ls", "-o", "json"}, nil, &resp)
+		assert.Greater(t, len(resp), 1)
+	})
+
+	t.Run("Clusters can be listed", func(t *testing.T) {
+		var resp []oks.Cluster
+		runJSON(t, []string{"kube", "cluster", "ls", "-o", "json"}, nil, &resp)
+		assert.Greater(t, len(resp), 1)
+	})
+	t.Run("Clusters can be listed by project (cluster ls)", func(t *testing.T) {
+		var resp []oks.Cluster
+		runJSON(t, []string{"kube", "cluster", "ls", "--project", project, "-o", "json"}, nil, &resp)
+		assert.Len(t, resp, 1)
+	})
+	t.Run("Clusters can be listed by project (project clusters)", func(t *testing.T) {
+		var resp []oks.Cluster
+		runJSON(t, []string{"kube", "project", "clusters", project, "-o", "json"}, nil, &resp)
+		assert.Len(t, resp, 1)
+	})
+
+	t.Run("Clusters can be described", func(t *testing.T) {
+		var resp oks.Cluster
+		runJSON(t, []string{"kube", "cluster", "desc", cluster, "-o", "json"}, nil, &resp)
+		assert.Equal(t, cluster, resp.Name)
+	})
+	t.Run("Clusters can be described with a valid --project", func(t *testing.T) {
+		var resp oks.Cluster
+		runJSON(t, []string{"kube", "cluster", "desc", cluster, "--project", project, "-o", "json"}, nil, &resp)
+		assert.Equal(t, cluster, resp.Name)
+	})
+	t.Run("describe fails with the wrong --project", func(t *testing.T) {
+		runWithError(t, []string{"kube", "cluster", "desc", cluster, "--project", emptyProject, "-o", "json"}, nil)
+	})
+	t.Run("describe fails with an invalid --project", func(t *testing.T) {
+		runWithError(t, []string{"kube", "cluster", "desc", cluster, "--project", "foobarbaz", "-o", "json"}, nil)
+	})
+
+	t.Run("Tags can be set", func(t *testing.T) {
 		var resp oks.Cluster
 		runJSON(t, []string{"kube", "cluster", "update", cluster, "--tags", "foo=bar,bar=baz", "-o", "json"}, nil, &resp)
 		assert.Equal(t, map[string]string{
 			"foo": "bar",
 			"bar": "baz",
 		}, resp.Tags)
-	}
+	})
 
-	t.Log("A nodepool can be created")
-	{
+	t.Run("A nodepool can be created", func(t *testing.T) {
 		_ = run(t, []string{"kube", "nodepool", "--cluster", cluster, "create", "--name", cluster, "--node-type", "tinav7.c1r1p3", "--zones", "eu-west-2a", "--desired-nodes", "2"}, nil)
 		var lst []any
 		runJSON(t, []string{"kube", "nodepool", "--cluster", cluster, "ls", "-o", "json"}, nil, &lst)
 		assert.Len(t, lst, 1)
-	}
+	})
+	t.Run("A nodepool creation fails with the wrong --project", func(t *testing.T) {
+		runWithError(t, []string{"kube", "nodepool", "--cluster", cluster, "create", "--name", emptyProject, "--project", emptyProject, "--node-type", "tinav7.c1r1p3", "--zones", "eu-west-2a", "--desired-nodes", "2"}, nil)
+	})
+	t.Run("A nodepool creation fails with an invalid --project", func(t *testing.T) {
+		runWithError(t, []string{"kube", "nodepool", "--project", "foobarbaz", "--cluster", cluster, "ls"}, nil)
+	})
 
-	t.Log("Kubectl can be run")
-	{
+	t.Run("Kubectl can be run", func(t *testing.T) {
 		var resp corev1.NodeList
 		runJSON(t, []string{"kube", "kubectl", "--cluster", cluster, "--", "get", "nodes", "-o", "json"}, nil, &resp)
 		assert.Equal(t, "List", resp.Kind)
-	}
+	})
+	t.Run("Kubectl can be run with a valid --project", func(t *testing.T) {
+		var resp corev1.NodeList
+		runJSON(t, []string{"kube", "kubectl", "--cluster", cluster, "--project", project, "--", "get", "nodes", "-o", "json"}, nil, &resp)
+		assert.Equal(t, "List", resp.Kind)
+	})
+	t.Run("Kubectl fails with the wrong --project", func(t *testing.T) {
+		runWithError(t, []string{"kube", "kubectl", "--cluster", cluster, "--project", emptyProject, "--", "get", "nodes"}, nil)
+	})
+	t.Run("Kubectl fails with an invalid --project", func(t *testing.T) {
+		runWithError(t, []string{"kube", "kubectl", "--cluster", cluster, "--project", "foobarbaz", "--", "get", "nodes"}, nil)
+	})
 }

--- a/docs/reference/octl_kube_api_CreateCluster.md
+++ b/docs/reference/octl_kube_api_CreateCluster.md
@@ -52,6 +52,7 @@ octl kube api CreateCluster [flags]
       --Tags stringToString                                           (default [])
       --Version string                                               Version of Kubernetes to be deployed
   -h, --help                                                         help for CreateCluster
+      --project string                                               project name
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/octl_kube_api_DeleteCluster.md
+++ b/docs/reference/octl_kube_api_DeleteCluster.md
@@ -13,7 +13,8 @@ octl kube api DeleteCluster id [flags]
 ### Options
 
 ```
-  -h, --help   help for DeleteCluster
+  -h, --help             help for DeleteCluster
+      --project string   project name
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/octl_kube_api_GetCluster.md
+++ b/docs/reference/octl_kube_api_GetCluster.md
@@ -13,7 +13,8 @@ octl kube api GetCluster id [flags]
 ### Options
 
 ```
-  -h, --help   help for GetCluster
+  -h, --help             help for GetCluster
+      --project string   project name
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/octl_kube_api_GetKubeconfig.md
+++ b/docs/reference/octl_kube_api_GetKubeconfig.md
@@ -9,10 +9,11 @@ octl kube api GetKubeconfig id [flags]
 ### Options
 
 ```
-      --Group string   
-      --Ttl string     
-      --User string    
-  -h, --help           help for GetKubeconfig
+      --Group string     
+      --Ttl string       
+      --User string      
+  -h, --help             help for GetKubeconfig
+      --project string   project name
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/octl_kube_api_UpdateCluster.md
+++ b/docs/reference/octl_kube_api_UpdateCluster.md
@@ -44,6 +44,7 @@ octl kube api UpdateCluster id [flags]
       --Tags stringToString                                           (default [])
       --Version string                                               
   -h, --help                                                         help for UpdateCluster
+      --project string                                               project name
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/octl_kube_api_UpgradeCluster.md
+++ b/docs/reference/octl_kube_api_UpgradeCluster.md
@@ -13,7 +13,8 @@ octl kube api UpgradeCluster id [flags]
 ### Options
 
 ```
-  -h, --help   help for UpgradeCluster
+  -h, --help             help for UpgradeCluster
+      --project string   project name
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/octl_kube_cluster.md
+++ b/docs/reference/octl_kube_cluster.md
@@ -5,7 +5,8 @@ cluster commands
 ### Options
 
 ```
-  -h, --help   help for cluster
+  -h, --help             help for cluster
+      --project string   project name
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/octl_kube_cluster_delete.md
+++ b/docs/reference/octl_kube_cluster_delete.md
@@ -30,6 +30,7 @@ octl kube cluster delete id [id]... [flags]
   -o, --output string               output format (raw, json, yaml, table, csv, none, base64, text)
       --payload string              JSON content for query body
       --profile string              Profile to use in profile file (by default, "default")
+      --project string              project name
       --single                      convert single entry lists to a single object
       --template string             JSON template file for query body
   -v, --verbose                     Verbose output

--- a/docs/reference/octl_kube_cluster_describe.md
+++ b/docs/reference/octl_kube_cluster_describe.md
@@ -30,6 +30,7 @@ octl kube cluster describe id [id]... [flags]
   -o, --output string               output format (raw, json, yaml, table, csv, none, base64, text)
       --payload string              JSON content for query body
       --profile string              Profile to use in profile file (by default, "default")
+      --project string              project name
       --single                      convert single entry lists to a single object
       --template string             JSON template file for query body
   -v, --verbose                     Verbose output

--- a/docs/reference/octl_kube_cluster_kubeconfig.md
+++ b/docs/reference/octl_kube_cluster_kubeconfig.md
@@ -30,6 +30,7 @@ octl kube cluster kubeconfig cluster_name_or_id [flags]
   -o, --output string               output format (raw, json, yaml, table, csv, none, base64, text)
       --payload string              JSON content for query body
       --profile string              Profile to use in profile file (by default, "default")
+      --project string              project name
       --single                      convert single entry lists to a single object
       --template string             JSON template file for query body
   -v, --verbose                     Verbose output

--- a/docs/reference/octl_kube_cluster_update.md
+++ b/docs/reference/octl_kube_cluster_update.md
@@ -60,6 +60,7 @@ octl kube cluster update id [id]... [flags]
   -o, --output string               output format (raw, json, yaml, table, csv, none, base64, text)
       --payload string              JSON content for query body
       --profile string              Profile to use in profile file (by default, "default")
+      --project string              project name
       --single                      convert single entry lists to a single object
       --template string             JSON template file for query body
   -v, --verbose                     Verbose output

--- a/docs/reference/octl_kube_kubectl.md
+++ b/docs/reference/octl_kube_kubectl.md
@@ -16,6 +16,7 @@ octl kube kubectl [octl_flags] -- kubectl_args [kubectl_flags] [flags]
 ```
       --cluster string   Name or ID of cluster
   -h, --help             help for kubectl
+      --project string   Name or ID of project
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/octl_kube_nodepool.md
+++ b/docs/reference/octl_kube_nodepool.md
@@ -5,7 +5,8 @@ nodepool commands
 ### Options
 
 ```
-  -h, --help   help for nodepool
+  -h, --help             help for nodepool
+      --project string   project name
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/octl_kube_nodepool_api.md
+++ b/docs/reference/octl_kube_nodepool_api.md
@@ -7,6 +7,7 @@ nodepool api calls
 ```
       --cluster string   Name or ID of cluster
   -h, --help             help for api
+      --project string   Name or ID of project
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/octl_kube_nodepool_api_Create.md
+++ b/docs/reference/octl_kube_nodepool_api_Create.md
@@ -97,6 +97,7 @@ octl kube nodepool api Create [flags]
   -o, --output string               output format (raw, json, yaml, table, csv, none, base64, text)
       --payload string              JSON content for query body
       --profile string              Profile to use in profile file (by default, "default")
+      --project string              Name or ID of project
       --single                      convert single entry lists to a single object
       --template string             JSON template file for query body
   -v, --verbose                     Verbose output

--- a/docs/reference/octl_kube_nodepool_api_Delete.md
+++ b/docs/reference/octl_kube_nodepool_api_Delete.md
@@ -25,6 +25,7 @@ octl kube nodepool api Delete id [flags]
   -o, --output string               output format (raw, json, yaml, table, csv, none, base64, text)
       --payload string              JSON content for query body
       --profile string              Profile to use in profile file (by default, "default")
+      --project string              Name or ID of project
       --single                      convert single entry lists to a single object
       --template string             JSON template file for query body
   -v, --verbose                     Verbose output

--- a/docs/reference/octl_kube_nodepool_api_Get.md
+++ b/docs/reference/octl_kube_nodepool_api_Get.md
@@ -25,6 +25,7 @@ octl kube nodepool api Get id [flags]
   -o, --output string               output format (raw, json, yaml, table, csv, none, base64, text)
       --payload string              JSON content for query body
       --profile string              Profile to use in profile file (by default, "default")
+      --project string              Name or ID of project
       --single                      convert single entry lists to a single object
       --template string             JSON template file for query body
   -v, --verbose                     Verbose output

--- a/docs/reference/octl_kube_nodepool_api_List.md
+++ b/docs/reference/octl_kube_nodepool_api_List.md
@@ -25,6 +25,7 @@ octl kube nodepool api List [flags]
   -o, --output string               output format (raw, json, yaml, table, csv, none, base64, text)
       --payload string              JSON content for query body
       --profile string              Profile to use in profile file (by default, "default")
+      --project string              Name or ID of project
       --single                      convert single entry lists to a single object
       --template string             JSON template file for query body
   -v, --verbose                     Verbose output

--- a/docs/reference/octl_kube_nodepool_api_Update.md
+++ b/docs/reference/octl_kube_nodepool_api_Update.md
@@ -97,6 +97,7 @@ octl kube nodepool api Update [flags]
   -o, --output string               output format (raw, json, yaml, table, csv, none, base64, text)
       --payload string              JSON content for query body
       --profile string              Profile to use in profile file (by default, "default")
+      --project string              Name or ID of project
       --single                      convert single entry lists to a single object
       --template string             JSON template file for query body
   -v, --verbose                     Verbose output

--- a/docs/reference/octl_kube_nodepool_create.md
+++ b/docs/reference/octl_kube_nodepool_create.md
@@ -62,6 +62,7 @@ octl kube nodepool create [flags]
   -o, --output string               output format (raw, json, yaml, table, csv, none, base64, text)
       --payload string              JSON content for query body
       --profile string              Profile to use in profile file (by default, "default")
+      --project string              project name
       --single                      convert single entry lists to a single object
       --template string             JSON template file for query body
   -v, --verbose                     Verbose output

--- a/docs/reference/octl_kube_nodepool_delete.md
+++ b/docs/reference/octl_kube_nodepool_delete.md
@@ -31,6 +31,7 @@ octl kube nodepool delete name [name]... [flags]
   -o, --output string               output format (raw, json, yaml, table, csv, none, base64, text)
       --payload string              JSON content for query body
       --profile string              Profile to use in profile file (by default, "default")
+      --project string              project name
       --single                      convert single entry lists to a single object
       --template string             JSON template file for query body
   -v, --verbose                     Verbose output

--- a/docs/reference/octl_kube_nodepool_describe.md
+++ b/docs/reference/octl_kube_nodepool_describe.md
@@ -31,6 +31,7 @@ octl kube nodepool describe name [name]... [flags]
   -o, --output string               output format (raw, json, yaml, table, csv, none, base64, text)
       --payload string              JSON content for query body
       --profile string              Profile to use in profile file (by default, "default")
+      --project string              project name
       --single                      convert single entry lists to a single object
       --template string             JSON template file for query body
   -v, --verbose                     Verbose output

--- a/docs/reference/octl_kube_nodepool_list.md
+++ b/docs/reference/octl_kube_nodepool_list.md
@@ -31,6 +31,7 @@ octl kube nodepool list [flags]
   -o, --output string               output format (raw, json, yaml, table, csv, none, base64, text)
       --payload string              JSON content for query body
       --profile string              Profile to use in profile file (by default, "default")
+      --project string              project name
       --single                      convert single entry lists to a single object
       --template string             JSON template file for query body
   -v, --verbose                     Verbose output

--- a/docs/reference/octl_kube_project.md
+++ b/docs/reference/octl_kube_project.md
@@ -42,4 +42,5 @@ project commands
 * [octl kube project quotas](octl_kube_project_quotas.md)	 - alias for api GetProjectQuotas id
 * [octl kube project snapshots](octl_kube_project_snapshots.md)	 - alias for api GetProjectSnapshots id
 * [octl kube project update](octl_kube_project_update.md)	 - alias for api UpdateProject  id
+* [octl kube project use](octl_kube_project_use.md)	 - Set a default project for cluster commands, reset it without args
 

--- a/docs/reference/octl_kube_project_use.md
+++ b/docs/reference/octl_kube_project_use.md
@@ -1,28 +1,15 @@
-## octl kube cluster list
+## octl kube project use
 
-alias for api ListAllClusters
-
-### Synopsis
-
-> *alias for api ListAllClusters*
-
-
+Set a default project for cluster commands, reset it without args
 
 ```
-octl kube cluster list [flags]
+octl kube project use [project_id_or_name] [flags]
 ```
 
 ### Options
 
 ```
-      --cursor string    
-      --deleted          
-  -h, --help             help for list
-      --limit int        
-      --name string      
-      --page int         
-      --status string    
-      --version string   
+  -h, --help   help for use
 ```
 
 ### Options inherited from parent commands
@@ -37,7 +24,6 @@ octl kube cluster list [flags]
   -o, --output string               output format (raw, json, yaml, table, csv, none, base64, text)
       --payload string              JSON content for query body
       --profile string              Profile to use in profile file (by default, "default")
-      --project string              project name
       --single                      convert single entry lists to a single object
       --template string             JSON template file for query body
   -v, --verbose                     Verbose output
@@ -49,5 +35,5 @@ octl kube cluster list [flags]
 
 ### SEE ALSO
 
-* [octl kube cluster](octl_kube_cluster.md)	 - cluster commands
+* [octl kube project](octl_kube_project.md)	 - project commands
 

--- a/pkg/preferences/preferences.go
+++ b/pkg/preferences/preferences.go
@@ -1,0 +1,71 @@
+package preferences
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/goccy/go-yaml"
+	"github.com/outscale/octl/pkg/debug"
+	"github.com/outscale/octl/pkg/messages"
+)
+
+type Kube struct {
+	DefaultProject string `yaml:"default_project,omitempty"`
+}
+
+type All struct {
+	Kube Kube `yaml:"kube,omitzero"`
+}
+
+var Preferences All
+
+func init() {
+	root, err := os.UserConfigDir()
+	if err != nil {
+		debug.Println("Unable to compute user preferences dir", err)
+		return
+	}
+	path := filepath.Join(root, "octl", "preferences.yaml")
+	fd, err := os.Open(path) //nolint:gosec
+	if errors.Is(err, fs.ErrNotExist) {
+		debug.Println("no user config file found", path)
+		return
+	}
+	if err != nil {
+		messages.Err("Unable to open preferences path: %w")
+		return
+	}
+	debug.Println("loading user config from", path)
+	err = yaml.NewDecoder(fd).Decode(&Preferences)
+	if err != nil {
+		messages.Err("Unable to load preferences: %w")
+	}
+}
+
+func (p *All) Save() (err error) {
+	root, err := os.UserConfigDir()
+	if err != nil {
+		debug.Println("Unable to compute user preferences dir", err)
+		return err
+	}
+	dir := filepath.Join(root, "octl")
+	err = os.MkdirAll(dir, 0o700)
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "preferences.yaml")
+	fd, err := os.Create(path) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	defer func() {
+		cerr := fd.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+	debug.Println("saving user preferences to", path)
+	return yaml.NewEncoder(fd).Encode(p)
+}


### PR DESCRIPTION
## Description

This PR adds a missing --project flag on all cluster commands, required to disambiguate clusters having the same name in  multiple projects.

It also adds a `octl kube project use <name>` command to define a default project to be used in `octl kube cluster/kubectl/nodepool` commands.

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [x] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
