### PR TITLE
🐛 fix(kubectl): kubectl does not report the kubectl version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
               id: version
               run: |
                   minorpatch=`grep kubectl go.mod | sed 's/.*kubectl v0//'`
-                  echo "KUBECTL_VERSION=1$minorpatch" >> $GITHUB_OUTPUT
+                  echo "KUBECTL_VERSION=1$minorpatch" | tee -a $GITHUB_OUTPUT
 
             - name: 📦 Run GoReleaser
               uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
@@ -47,4 +47,4 @@ jobs:
                 args: release --clean
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                KUBECTL_VERSION: ${{ steps.version.KUBECTL_VERSION }}
+                KUBECTL_VERSION: ${{ steps.version.outputs.KUBECTL_VERSION }}


### PR DESCRIPTION
## Description

The Client Version is not properly set:
```
octl kube kubectl --cluster dev -- version
Client Version: v+octl
Kustomize Version: v5.7.1
Server Version: v1.35.1
```

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [x] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
