### PR TITLE
🐛 fix: avoid duplicate service group in usage

### DIFF
--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -36,10 +36,14 @@ func NewBuilder[T any](provider string, helpURL string) *Builder[T] {
 
 // Build builds the high-level API, must be run after BuildAPI as aliases might use API flags.
 func (b *Builder[T]) Build(rootCmd, apiCmd *cobra.Command) {
-	rootCmd.AddGroup(&cobra.Group{
-		ID:    "service",
-		Title: "service",
-	})
+	if !lo.ContainsBy(rootCmd.Groups(), func(item *cobra.Group) bool {
+		return item.ID == "service"
+	}) {
+		rootCmd.AddGroup(&cobra.Group{
+			ID:    "service",
+			Title: "service",
+		})
+	}
 	if apiCmd == nil {
 		apiCmd, _ = lo.Find(rootCmd.Commands(), func(c *cobra.Command) bool { return c.Name() == "api" })
 	}


### PR DESCRIPTION
## Description

The service group may appear multiple times in usage:
```
octl kube -h
OUTSCALE Kubernetes as a Service (OKS) management

Usage:
  octl kube [command]

Aliases:
  kube, oks

api
  api         kube api calls

service
  cluster     cluster commands
  nodepool    nodepool commands
  project     project commands
  publicip    publicip commands
  quota       quota commands

service
  cluster     cluster commands
  nodepool    nodepool commands
  project     project commands
  publicip    publicip commands
  quota       quota commands
```

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
