### PR TITLE
🐛 fix(version): fix pkg versions in --version

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,15 +7,16 @@ package cmd
 
 import (
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/outscale/octl/cmd/prerun"
 	"github.com/outscale/octl/pkg/markdown"
 	"github.com/outscale/octl/pkg/version"
+	"github.com/outscale/osc-sdk-go/v3/pkg/oks"
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
 	"github.com/outscale/osc-sdk-go/v3/pkg/profile"
-	sdkversion "github.com/outscale/osc-sdk-go/v3/pkg/version"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 )
@@ -48,15 +49,7 @@ var rootCmd = &cobra.Command{
 		prerun.CheckFalse(cmd, args)
 		prerun.CheckUpdate(cmd, args)
 	},
-	Run: func(cmd *cobra.Command, _ []string) {
-		if b, _ := cmd.Flags().GetBool("version"); b {
-			fmt.Printf("octl version %s\n", version.Version)
-			fmt.Printf("based on Go SDK %s\n", sdkversion.Version)
-			fmt.Printf("Providers:\n* iaas: %s\n", osc.Version)
-			return
-		}
-		_ = cmd.Help()
-	},
+	Run:               root,
 	SilenceErrors:     true, // do not display errors when an error occurred, we do it
 	SilenceUsage:      true, // do not display usage when an error occurred, the user will need to call -h
 	DisableAutoGenTag: true,
@@ -110,4 +103,25 @@ func init() {
 		cf, _ := loadConfig(cmd)
 		return lo.Map(lo.Keys(cf.Profiles), func(k string, _ int) cobra.Completion { return cobra.Completion(k) }), cobra.ShellCompDirectiveDefault
 	})
+}
+
+func root(cmd *cobra.Command, _ []string) {
+	if b, _ := cmd.Flags().GetBool("version"); b {
+		fmt.Printf("octl version %s\n", version.Version)
+		build, ok := debug.ReadBuildInfo()
+		if ok {
+			fmt.Println("Based on:")
+			for _, dep := range build.Deps {
+				switch dep.Path {
+				case "github.com/outscale/osc-sdk-go/v3", "github.com/aws/aws-sdk-go-v2/service/s3", "k8s.io/kubectl":
+					fmt.Printf("* %s %s\n", dep.Path, dep.Version)
+				}
+			}
+		}
+		fmt.Println("Providers:")
+		fmt.Printf("* osc: %s\n", osc.Version)
+		fmt.Printf("* oks: %s\n", oks.Version)
+		return
+	}
+	_ = cmd.Help()
 }

--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,8 @@ require (
 	github.com/mattn/go-isatty v0.0.21
 	github.com/minio/selfupdate v0.6.0
 	github.com/outscale/goutils/oks v0.0.1
-	github.com/outscale/goutils/sdk v0.0.5
-	github.com/outscale/osc-sdk-go/v3 v3.0.0-rc.3
+	github.com/outscale/goutils/sdk v0.0.4
+	github.com/outscale/osc-sdk-go/v3 v3.0.0-rc.3.0.20260709150001-abf6e77bc1d0
 	github.com/samber/lo v1.53.0
 	github.com/sigstore/sigstore-go v1.1.4
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -439,10 +439,10 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/outscale/goutils/oks v0.0.1 h1:7i+a7iD9VlYgj8sTz7Na+9GYtW3gsbpDrmykYAnlCb0=
 github.com/outscale/goutils/oks v0.0.1/go.mod h1:K9VSlCA2l6MjA31TD2c3FLceR9z48qf7NO3aKxF8Nm0=
-github.com/outscale/goutils/sdk v0.0.5 h1:UVu7uC38VOSCPqeCORsw1rKWaoHrsv+TTp6TGUHenjo=
-github.com/outscale/goutils/sdk v0.0.5/go.mod h1:LiXmAIA3CAXCdanEARKQ3Q/Lb8n8dKeGSbPRxIe43kc=
-github.com/outscale/osc-sdk-go/v3 v3.0.0-rc.3 h1:dE2Swgp2M3gSdv5Yx28JFHF1LBhGzVOb6NbVjyshFAs=
-github.com/outscale/osc-sdk-go/v3 v3.0.0-rc.3/go.mod h1:Yi0j2XAZ0/8g0ObVFofMSL5+IuNIDp/AiEI6gXc7txc=
+github.com/outscale/goutils/sdk v0.0.4 h1:hm+LZyeHUBYj066MjVVYYEPnlZRQSv4v74TZgfIQkRM=
+github.com/outscale/goutils/sdk v0.0.4/go.mod h1:LiXmAIA3CAXCdanEARKQ3Q/Lb8n8dKeGSbPRxIe43kc=
+github.com/outscale/osc-sdk-go/v3 v3.0.0-rc.3.0.20260709150001-abf6e77bc1d0 h1:pcjUB56ldZ+4AvJcO1sEz7oKJsU2GXWsxjmlffG5siE=
+github.com/outscale/osc-sdk-go/v3 v3.0.0-rc.3.0.20260709150001-abf6e77bc1d0/go.mod h1:Yi0j2XAZ0/8g0ObVFofMSL5+IuNIDp/AiEI6gXc7txc=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=


### PR DESCRIPTION
## Description

This PR fetches the SDK versions from the build info. It adds the S3 and kubectl version.

Before:
```shell
octl --version
octl version v0.0.28
based on Go SDK v3.0.0+dev // wrong
Providers:
* iaas: v1.41.0
```
After:
```shell
octl --version
octl version v0.0.28
Based on:
* github.com/aws/aws-sdk-go-v2/service/s3 v1.72.3
* github.com/outscale/osc-sdk-go/v3 v3.0.0-rc.3
* k8s.io/kubectl v0.35.3
Providers:
* osc: v1.41.0
* oks: v1.0
```

Notes:
* the v1.0 oks version is reported by the OpenAPI spec/the SDK,
* as the name kube is too general to be used to report the OKS SDK version (because the octl kube namespace includes many things that are not part of the SDK), providers use the same name as the subpackage name in the Go SDK 

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
