### PR TITLE
🚸 ux(profile): add profile name in profile current

### DIFF
--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -131,12 +131,22 @@ func listProfiles(cmd *cobra.Command, _ []string) {
 }
 
 func currentProfile(cmd *cobra.Command, _ []string) {
+	cf, err := loadConfig(cmd)
+	if err != nil {
+		messages.ExitErr(err)
+	}
 	out, _, err := output.NewFromFlags(cmd.Flags(), "yaml", "", profileColumns, false, true)
 	if err != nil {
 		messages.ExitErr(err)
 	}
-	p := loadProfile(cmd)
-	_ = out.Format(cmd.Context(), os.Stdout, p)
+	prof := *loadProfile(cmd)
+	name, _ := cmd.Flags().GetString("profile")
+	if name == "" {
+		name, _ = lo.FindKeyBy(cf.Profiles, func(name string, p profile.Profile) bool {
+			return prof.AccessKey == p.AccessKey && prof.Region == p.Region
+		})
+	}
+	_ = out.Format(cmd.Context(), os.Stdout, profileEntry{Name: name, Profile: prof, Default: prof.Default})
 }
 
 func addProfile(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
## Description

`octl profile current` only displayed the content of the profile, but not its name.

This PR adds the profile name to the output.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [x] Other (specify): ux

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
