### PR TITLE
♻️ refacto(jq): isolate json conversion filter

### DIFF
--- a/pkg/output/filter/jq.go
+++ b/pkg/output/filter/jq.go
@@ -6,7 +6,6 @@ package filter
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"iter"
 
@@ -21,7 +20,7 @@ type JQ struct {
 func NewJQ(s string) (JQ, error) {
 	query, err := gojq.Parse(s)
 	if err != nil {
-		return JQ{}, fmt.Errorf("parse jq filter: %w", err)
+		return JQ{}, fmt.Errorf("invalid jq filter: %w", err)
 	}
 	return JQ{query: query}, nil
 }
@@ -33,18 +32,7 @@ func (j JQ) Filter(ctx context.Context, seq iter.Seq[result.Result]) iter.Seq[re
 				_ = yield(v)
 				return
 			}
-			buf, err := json.Marshal(v.Ok)
-			if err != nil {
-				_ = yield(result.Result{Error: fmt.Errorf("jq to JSON: %w", err)})
-				return
-			}
-			var raw any
-			err = json.Unmarshal(buf, &raw)
-			if err != nil {
-				_ = yield(result.Result{Error: fmt.Errorf("jq from JSON: %w", err)})
-				return
-			}
-			iter := j.query.RunWithContext(ctx, raw)
+			iter := j.query.RunWithContext(ctx, v.Ok)
 			for {
 				v, ok := iter.Next()
 				if !ok {

--- a/pkg/output/filter/json.go
+++ b/pkg/output/filter/json.go
@@ -1,0 +1,43 @@
+/*
+SPDX-FileCopyrightText: 2026 Outscale SAS <opensource@outscale.com>
+SPDX-License-Identifier: BSD-3-Clause
+*/
+package filter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"iter"
+
+	"github.com/outscale/octl/pkg/output/result"
+)
+
+type JSON struct{}
+
+func (j JSON) Filter(ctx context.Context, seq iter.Seq[result.Result]) iter.Seq[result.Result] {
+	return func(yield func(result.Result) bool) {
+		for v := range seq {
+			if v.Error != nil {
+				_ = yield(v)
+				return
+			}
+			buf, err := json.Marshal(v.Ok)
+			if err != nil {
+				_ = yield(result.Result{Error: fmt.Errorf("to JSON: %w", err)})
+				return
+			}
+			var raw any
+			err = json.Unmarshal(buf, &raw)
+			if err != nil {
+				_ = yield(result.Result{Error: fmt.Errorf("from JSON: %w", err)})
+				return
+			}
+			if !yield(result.Result{Ok: raw}) {
+				return
+			}
+		}
+	}
+}
+
+var _ Interface = JSON{}

--- a/pkg/output/flags.go
+++ b/pkg/output/flags.go
@@ -45,6 +45,9 @@ func NewFromFlags(fs *pflag.FlagSet, out, contentField string, cols config.Colum
 		}
 		filters = append(filters, jqf)
 	}
+	if len(filters) > 0 {
+		filters = slices.Insert(filters, 0, filter.Interface(filter.JSON{}))
+	}
 
 	var fmter format.Interface
 	switch out {


### PR DESCRIPTION
## Description

The jq filter does a JSON to/from conversion to convert the input to a json.RawMessage format supported by the gojq package.

When multiple jq filters are applied, this leads to redundant/useless conversions. This PR isolates the JSON conversion to a separate filter that is applied before jq filters..

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [x] Unit tests
- [x] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
