### PR TITLE
🐛 fix(watch): consecutive calls fetched consecutive pages

### DIFF
--- a/pkg/output/read/fetch.go
+++ b/pkg/output/read/fetch.go
@@ -19,6 +19,26 @@ type FetchPage struct {
 	Args   []reflect.Value
 }
 
+func (f *FetchPage) Clone() FetchPage {
+	nArgs := make([]reflect.Value, len(f.Args))
+	nArgs[0] = f.Args[0] // ctx
+	for i := 1; i < len(f.Args); i++ {
+		if f.Args[i].Kind() == reflect.Pointer {
+			nval := reflect.New(f.Args[i].Type().Elem())
+			nval.Elem().Set(f.Args[i].Elem())
+			nArgs[i] = nval
+		} else {
+			nval := reflect.New(f.Args[i].Type())
+			nval.Elem().Set(f.Args[i])
+			nArgs[i] = nval.Elem()
+		}
+	}
+	return FetchPage{
+		Method: f.Method,
+		Args:   nArgs,
+	}
+}
+
 func (f *FetchPage) Call(ctx context.Context) []reflect.Value {
 	// display a spinner if API call lasts more than 200ms
 	stopSpinner := func() {}

--- a/pkg/output/read/pager_first_item.go
+++ b/pkg/output/read/pager_first_item.go
@@ -22,6 +22,7 @@ func (FirstItemPager) HasMore(res reflect.Value) bool {
 }
 
 func (FirstItemPager) NextItem(res reflect.Value, fetch FetchPage, nextIndex int) (FetchPage, bool) {
+	fetch = fetch.Clone()
 	for _, arg := range fetch.Args {
 		arg = reflect.Indirect(arg)
 		if arg.Kind() != reflect.Struct {

--- a/pkg/output/read/pager_oos.go
+++ b/pkg/output/read/pager_oos.go
@@ -39,6 +39,7 @@ func (OOSPager) nextToken(res reflect.Value) string {
 }
 
 func (p OOSPager) NextItem(res reflect.Value, fetch FetchPage, _ int) (FetchPage, bool) {
+	fetch = fetch.Clone()
 	nextToken := p.nextToken(res)
 	if nextToken == "" {
 		return fetch, false

--- a/pkg/output/read/pager_token.go
+++ b/pkg/output/read/pager_token.go
@@ -31,6 +31,7 @@ func (p TokenPager) HasMore(res reflect.Value) bool {
 }
 
 func (p TokenPager) NextItem(res reflect.Value, fetch FetchPage, _ int) (FetchPage, bool) {
+	fetch = fetch.Clone()
 	nextToken := p.nextToken(res)
 	if nextToken == "" {
 		return fetch, false


### PR DESCRIPTION
## Description

The pagination helpers did override the source query. The second API call made by `watch` would call the next page, and so on...

This PR modifies pagination so that it operates on a clone of the source query.
 
## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
