### PR TITLE
✨ feat: add reverse filter

### DIFF
--- a/cmd/iaas_test.go
+++ b/cmd/iaas_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -408,4 +409,13 @@ func TestDryRun(t *testing.T) {
 	var req osc.ReadVmsRequest
 	runJSON(t, []string{"iaas", "vm", "ls", "--subregion", "foo", "--dry-run", "-o", "json"}, nil, &req)
 	assert.Equal(t, osc.ReadVmsRequest{Filters: &osc.FiltersVm{SubregionNames: &[]string{"foo"}}}, req)
+}
+
+func TestReverse(t *testing.T) {
+	var imgs []string
+	runJSON(t, []string{"iaas", "image", "ls", "--jq", ".ImageId", "-o", "json"}, nil, &imgs)
+	var reverse []string
+	runJSON(t, []string{"iaas", "image", "ls", "--jq", ".ImageId", "--reverse", "-o", "json"}, nil, &reverse)
+	slices.Reverse(reverse)
+	assert.Equal(t, imgs, reverse)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,6 +80,8 @@ func init() {
 
 	rootCmd.PersistentFlags().String("jq", "", "jq filter")
 	rootCmd.PersistentFlags().StringSlice("filter", nil, `comma separated list of filters for results - name:value,name:value, alias for jq filter 'select(.name | tostring | test("value"))'`)
+	rootCmd.PersistentFlags().Bool("reverse", false, "reverse the order of results")
+	_ = rootCmd.PersistentFlags().MarkHidden("reverse")
 
 	rootCmd.PersistentFlags().Bool("watch", false, "repeatedly call the API and display changes")
 	rootCmd.PersistentFlags().String("waitfor", "", "repeatedly call the API until the specified jq expression returns 1/true or a non empty result")

--- a/pkg/output/filter/reverse.go
+++ b/pkg/output/filter/reverse.go
@@ -1,0 +1,29 @@
+/*
+SPDX-FileCopyrightText: 2026 Outscale SAS <opensource@outscale.com>
+SPDX-License-Identifier: BSD-3-Clause
+*/
+package filter
+
+import (
+	"context"
+	"iter"
+	"slices"
+
+	"github.com/outscale/octl/pkg/output/result"
+)
+
+type Reverse struct{}
+
+func (j Reverse) Filter(ctx context.Context, seq iter.Seq[result.Result]) iter.Seq[result.Result] {
+	return func(yield func(result.Result) bool) {
+		res := slices.Collect(seq)
+		slices.Reverse(res)
+		for _, v := range res {
+			if !yield(v) {
+				return
+			}
+		}
+	}
+}
+
+var _ Interface = Reverse{}

--- a/pkg/output/flags.go
+++ b/pkg/output/flags.go
@@ -51,6 +51,10 @@ func NewFromFlags(fs *pflag.FlagSet, out, contentField string, cols config.Colum
 		}
 		filters = append(filters, jqf)
 	}
+	reverse, _ := fs.GetBool("reverse")
+	if reverse {
+		filters = append(filters, filter.Reverse{})
+	}
 	if len(filters) > 0 {
 		filters = slices.Insert(filters, 0, filter.Interface(filter.JSON{}))
 	}


### PR DESCRIPTION
## Description

This PR adds a --reverse filter, to reverse the order of results (useful for tailing logs, as ReadApiLogs returns the oldest log first).

To reduce clutter on the usage page, the flag is hidden.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [x] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
