### PR TITLE
🚸 ux(iaas): allow use of device name instead of volume id

### DIFF
--- a/cmd/iaas.go
+++ b/cmd/iaas.go
@@ -49,6 +49,9 @@ func oapi(cmd *cobra.Command, args []string) {
 	p := loadProfile(cmd)
 	cl, err := osc.NewClient(p, sdkOptions(cmd)...)
 	if err == nil {
+		err = deviceToVolumeID(cmd, cl)
+	}
+	if err == nil {
 		err = runner.Run[*osc.Client, *osc.ErrorResponse](cmd, args, cl, config.For("iaas"))
 	}
 	if err != nil {

--- a/cmd/iaas_test.go
+++ b/cmd/iaas_test.go
@@ -419,3 +419,10 @@ func TestReverse(t *testing.T) {
 	slices.Reverse(reverse)
 	assert.Equal(t, imgs, reverse)
 }
+
+func TestVolumeByDeviceName(t *testing.T) {
+	var resp osc.Volume
+	runJSON(t, []string{"iaas", "vol", "desc", "/dev/sda1", "-o", "json"}, nil, &resp)
+	require.Len(t, resp.LinkedVolumes, 1)
+	assert.Equal(t, "/dev/sda1", resp.LinkedVolumes[0].DeviceName)
+}

--- a/cmd/iaas_volume.go
+++ b/cmd/iaas_volume.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+
+	"github.com/outscale/goutils/sdk/metadata"
+	"github.com/outscale/goutils/sdk/ptr"
+	"github.com/outscale/octl/pkg/messages"
+	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func deviceToVolumeID(cmd *cobra.Command, cl *osc.Client) error {
+	if err := doDeviceToVolumeID(cmd, cl); err != nil {
+		return err
+	}
+	return doDevicesToVolumeIDs(cmd, cl)
+}
+
+func doDeviceToVolumeID(cmd *cobra.Command, cl *osc.Client) error {
+	f := cmd.Flag("VolumeId")
+	if f == nil {
+		return nil
+	}
+	dev := f.Value.String()
+	if !strings.HasPrefix(dev, "/dev/") {
+		return nil
+	}
+	vols, err := fetchVolumeIDs(cmd.Context(), cl, dev)
+	switch {
+	case err != nil:
+		return err
+	case len(vols) > 0:
+		_ = f.Value.Set(vols[0])
+	}
+	return nil
+}
+
+func doDevicesToVolumeIDs(cmd *cobra.Command, cl *osc.Client) error {
+	f := cmd.Flag("Filters.VolumeIds")
+	if f == nil {
+		return nil
+	}
+	fs, ok := f.Value.(pflag.SliceValue)
+	if !ok {
+		return nil
+	}
+	devs := lo.Filter(fs.GetSlice(), func(dev string, _ int) bool {
+		return strings.HasPrefix(dev, "/dev/")
+	})
+	if len(devs) == 0 {
+		return nil
+	}
+	vols, err := fetchVolumeIDs(cmd.Context(), cl, devs...)
+	switch {
+	case err != nil:
+		return err
+	case len(vols) > 0:
+		keep := lo.Filter(fs.GetSlice(), func(dev string, _ int) bool {
+			return !strings.HasPrefix(dev, "/dev/")
+		})
+		keep = append(keep, vols...)
+		_ = fs.Replace(keep)
+	}
+	return nil
+}
+
+func fetchVolumeIDs(ctx context.Context, cl *osc.Client, devs ...string) ([]string, error) {
+	vm, err := metadata.GetInstanceID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	messages.Info("Fetching device(s) %s from instance %s", strings.Join(devs, ", "), vm)
+	resp, err := cl.ReadVolumes(ctx, osc.ReadVolumesRequest{
+		Filters: &osc.FiltersVolume{
+			LinkVolumeDeviceNames: &devs,
+			LinkVolumeVmIds:       &[]string{vm},
+		},
+	})
+	switch {
+	case err != nil:
+		return nil, err
+	case len(ptr.From(resp.Volumes)) > 0:
+		vols := lo.Map(*resp.Volumes, func(v osc.Volume, _ int) string {
+			return v.VolumeId
+		})
+		messages.Info("Using volume ID(s) %s", strings.Join(vols, ", "))
+		return vols, nil
+	default:
+		return nil, nil
+	}
+}

--- a/docs/usage/iaas.md
+++ b/docs/usage/iaas.md
@@ -80,3 +80,13 @@ The API can be directly called, with a `raw` output:
 ```sh
 octl iaas api ReadVms --Filters.VmStateNames running
 ```
+
+## Referencing volumes on the local machine
+
+When running octl on a VM, you can reference the volume attached to the local VM by device name:
+```sh
+octl iaas vol desc /dev/xvdb
+```
+```sh
+octl iaas snap create --volume-id /dev/xvdb
+```


### PR DESCRIPTION
## Description

This PR allows the use of device names to operate on volumes attached to the VM running octl:
```
octl iaas vol desc /dev/sda1
```
```
octl iaas snap create --volume-id /dev/sda1
```
```
octl iaas vol update /dev/sda1 --size 32
```

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [x] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
