### PR TITLE
✨ feat(preferences): profile-based preferences

### DIFF
--- a/cmd/kube.go
+++ b/cmd/kube.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/outscale/octl/cmd/prerun"
 	"github.com/outscale/octl/pkg/builder"
 	"github.com/outscale/octl/pkg/config"
 	"github.com/outscale/octl/pkg/debug"
@@ -20,6 +21,7 @@ import (
 	"github.com/outscale/octl/pkg/preferences"
 	"github.com/outscale/octl/pkg/runner"
 	"github.com/outscale/osc-sdk-go/v3/pkg/oks"
+	"github.com/outscale/osc-sdk-go/v3/pkg/profile"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 )
@@ -51,11 +53,11 @@ func init() {
 
 	// Add --project flag to kube cluster commands
 	clusterCmd, _ := lo.Find(oksCmd.Commands(), func(c *cobra.Command) bool { return c.Name() == "cluster" })
-	clusterCmd.PersistentFlags().String("project", preferences.Preferences.Kube.DefaultProject, "Name or ID of project")
+	clusterCmd.PersistentFlags().String("project", "", "Name or ID of project")
 	_ = flags.MarkAsNoForward(clusterCmd.PersistentFlags(), "project")
 	clusterCmd.PersistentPreRunE = clusterArgToID
 	clusterCreateCmd, _ := lo.Find(clusterCmd.Commands(), func(c *cobra.Command) bool { return c.Name() == "create" })
-	_ = flags.SetDefault(clusterCreateCmd.Flags(), "project", preferences.Preferences.Kube.DefaultProject)
+	_ = flags.SetDefault(clusterCreateCmd.Flags(), "project", "")
 
 	// Remap <cluster ls --project name> to <project clusters name>
 	projectCmd, _ := lo.Find(oksCmd.Commands(), func(c *cobra.Command) bool { return c.Name() == "project" })
@@ -116,6 +118,7 @@ func projectArgToID(cmd *cobra.Command, args []string) error {
 	if cmd.Name() == "use" {
 		return nil
 	}
+
 	debug.Println("projectArgToID")
 	p := loadProfile(cmd)
 	cl, err := oks.NewClient(p, sdkOptions(cmd)...)
@@ -168,6 +171,9 @@ func flagNamesToID(cmd *cobra.Command, args []string) error {
 }
 
 func projectNameToID(ctx context.Context, name string, cl *oks.Client) (string, error) {
+	if name == "" {
+		name = prerun.PreferencesFrom(ctx).Kube.DefaultProject
+	}
 	if name == "" {
 		return "", nil
 	}
@@ -222,19 +228,24 @@ func clusterNameToID(ctx context.Context, name, project string, cl *oks.Client) 
 	}
 }
 
-func useProject(c *cobra.Command, args []string) {
+func useProject(cmd *cobra.Command, args []string) {
 	var def string
 	if len(args) > 0 {
 		def = args[0]
 	}
-	preferences.Preferences.Kube.DefaultProject = def
-	err := preferences.Preferences.Save()
+	prof, _ := cmd.Flags().GetString("profile")
+	if prof == "" {
+		prof = profile.DefaultProfile
+	}
+	// retro compatibility
+	_ = preferences.SetGlobal(func(prefs *preferences.Preferences) { prefs.Kube.DefaultProject = "" })
+	err := preferences.Set(prof, func(prefs *preferences.Preferences) { prefs.Kube.DefaultProject = def })
 	if err != nil {
 		messages.ExitErr(err)
 	}
 	if def == "" {
-		messages.Success("The default project has been reset")
+		messages.Success("The default project has been reset for profile %q", prof)
 	} else {
-		messages.Success("%q is now the default project for all octl kube commands", def)
+		messages.Success("%q is now the default project for profile %q", def, prof)
 	}
 }

--- a/cmd/kube_kubeapi.go
+++ b/cmd/kube_kubeapi.go
@@ -9,7 +9,6 @@ import (
 	"github.com/outscale/octl/pkg/config"
 	"github.com/outscale/octl/pkg/flags"
 	"github.com/outscale/octl/pkg/messages"
-	"github.com/outscale/octl/pkg/preferences"
 	"github.com/outscale/octl/pkg/runner"
 	"github.com/outscale/osc-sdk-go/v3/pkg/oks"
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
@@ -34,7 +33,7 @@ func buildKubeAPI[Client any](provider string, cmd, parent *cobra.Command, getcl
 			_ = child.MarkPersistentFlagRequired("cluster")
 		} else {
 			child.Flags().String("cluster", "", "[REQUIRED] Name or ID of cluster")
-			child.Flags().String("project", preferences.Preferences.Kube.DefaultProject, "Name or ID of project")
+			child.Flags().String("project", "", "Name or ID of project")
 			_ = child.MarkFlagRequired("cluster")
 			_ = flags.MarkAsNoForward(child.Flags(), "project")
 		}

--- a/cmd/kube_kubectl.go
+++ b/cmd/kube_kubectl.go
@@ -14,7 +14,6 @@ import (
 	"github.com/outscale/octl/pkg/debug"
 	"github.com/outscale/octl/pkg/flags"
 	"github.com/outscale/octl/pkg/messages"
-	"github.com/outscale/octl/pkg/preferences"
 	"github.com/outscale/osc-sdk-go/v3/pkg/oks"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
@@ -120,6 +119,6 @@ func init() {
 	oksCmd.AddCommand(kubectlCmd)
 	kubectlCmd.Flags().String("cluster", "", "Name or ID of cluster")
 	_ = kubectlCmd.MarkFlagRequired("cluster")
-	kubectlCmd.Flags().String("project", preferences.Preferences.Kube.DefaultProject, "Name or ID of project")
+	kubectlCmd.Flags().String("project", "", "Name or ID of project")
 	_ = flags.MarkAsNoForward(kubectlCmd.Flags(), "project")
 }

--- a/cmd/kube_test.go
+++ b/cmd/kube_test.go
@@ -90,4 +90,27 @@ func TestKube(t *testing.T) {
 	t.Run("Kubectl fails with an invalid --project", func(t *testing.T) {
 		runWithError(t, []string{"kube", "kubectl", "--cluster", cluster, "--project", "foobarbaz", "--", "get", "nodes"}, nil)
 	})
+
+	t.Run("A default project can be set", func(t *testing.T) {
+		_ = run(t, []string{"kube", "project", "use", emptyProject}, nil)
+		defer func() {
+			_ = run(t, []string{"kube", "project", "use"}, nil)
+		}()
+		runWithError(t, []string{"kube", "kubectl", "--cluster", cluster, "--", "get", "nodes"}, nil)
+	})
+	t.Run("A default project is ignored if flag si set", func(t *testing.T) {
+		_ = run(t, []string{"kube", "project", "use", emptyProject}, nil)
+		defer func() {
+			_ = run(t, []string{"kube", "project", "use"}, nil)
+		}()
+		_ = run(t, []string{"kube", "kubectl", "--cluster", cluster, "--project", project, "--", "get", "nodes"}, nil)
+	})
+	t.Run("A default project is ignored when set on another profile", func(t *testing.T) {
+		_, _ = try(t.Context(), []string{"profile", "add", "foo", "--ak", "foo", "--sk", "foo"}, nil)
+		_ = run(t, []string{"kube", "project", "use", emptyProject, "--profile", "foo"}, nil)
+		defer func() {
+			_ = run(t, []string{"kube", "project", "use", "--profile", "foo"}, nil)
+		}()
+		_ = run(t, []string{"kube", "kubectl", "--cluster", cluster, "--", "get", "nodes"}, nil)
+	})
 }

--- a/cmd/prerun/preferences.go
+++ b/cmd/prerun/preferences.go
@@ -1,0 +1,36 @@
+package prerun
+
+import (
+	"context"
+
+	"github.com/outscale/octl/pkg/messages"
+	"github.com/outscale/octl/pkg/preferences"
+	"github.com/outscale/osc-sdk-go/v3/pkg/profile"
+	"github.com/spf13/cobra"
+)
+
+type preferenceKey struct{}
+
+func contextWithPreferences(ctx context.Context, p preferences.Preferences) context.Context {
+	return context.WithValue(ctx, preferenceKey{}, p)
+}
+
+func PreferencesFrom(ctx context.Context) preferences.Preferences {
+	p := ctx.Value(preferenceKey{})
+	if p == nil {
+		return preferences.Preferences{}
+	}
+	return p.(preferences.Preferences)
+}
+
+func LoadPreferences(cmd *cobra.Command) {
+	prof, _ := cmd.Flags().GetString("profile")
+	if prof == "" {
+		prof = profile.DefaultProfile
+	}
+	prefs, err := preferences.Get(prof)
+	if err != nil {
+		messages.Err(err.Error())
+	}
+	cmd.SetContext(contextWithPreferences(cmd.Context(), prefs))
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,7 @@ var rootCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		prerun.CheckFalse(cmd, args)
 		prerun.CheckUpdate(cmd, args)
+		prerun.LoadPreferences(cmd)
 	},
 	Run:               root,
 	SilenceErrors:     true, // do not display errors when an error occurred, we do it

--- a/pkg/preferences/preferences.go
+++ b/pkg/preferences/preferences.go
@@ -2,10 +2,12 @@ package preferences
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 
+	"dario.cat/mergo"
 	"github.com/goccy/go-yaml"
 	"github.com/outscale/octl/pkg/debug"
 	"github.com/outscale/octl/pkg/messages"
@@ -15,36 +17,80 @@ type Kube struct {
 	DefaultProject string `yaml:"default_project,omitempty"`
 }
 
-type All struct {
+type Preferences struct {
 	Kube Kube `yaml:"kube,omitzero"`
 }
 
-var Preferences All
+type File struct {
+	Global     Preferences            `yaml:"global,omitzero"`
+	PerProfile map[string]Preferences `yaml:"per_profile,omitzero"`
+}
 
-func init() {
+func Load() (File, error) {
 	root, err := os.UserConfigDir()
 	if err != nil {
 		debug.Println("Unable to compute user preferences dir", err)
-		return
+		return File{}, err
 	}
 	path := filepath.Join(root, "octl", "preferences.yaml")
 	fd, err := os.Open(path) //nolint:gosec
 	if errors.Is(err, fs.ErrNotExist) {
 		debug.Println("no user config file found", path)
-		return
+		return File{}, nil
 	}
 	if err != nil {
-		messages.Err("Unable to open preferences path: %w")
-		return
+		messages.Err("Unable to open preferences path: %w", err)
+		return File{}, err
 	}
 	debug.Println("loading user config from", path)
-	err = yaml.NewDecoder(fd).Decode(&Preferences)
+	var pf File
+	err = yaml.NewDecoder(fd).Decode(&pf)
 	if err != nil {
-		messages.Err("Unable to load preferences: %w")
+		return File{}, err
 	}
+	return pf, nil
 }
 
-func (p *All) Save() (err error) {
+func Get(profile string) (Preferences, error) {
+	pf, err := Load()
+	if err != nil {
+		return Preferences{}, fmt.Errorf("unable to load preferences: %w", err)
+	}
+	if pf.PerProfile == nil {
+		return pf.Global, nil
+	}
+	prefs := pf.PerProfile[profile]
+	err = mergo.Merge(&prefs, pf.Global)
+	if err != nil {
+		messages.Err("Unable to process preferences: %w", err)
+	}
+	return prefs, nil
+}
+
+func Set(profile string, fn func(prefs *Preferences)) error {
+	pf, err := Load()
+	if err != nil {
+		return fmt.Errorf("unable to load preferences: %w", err)
+	}
+	if pf.PerProfile == nil {
+		pf.PerProfile = map[string]Preferences{}
+	}
+	pref := pf.PerProfile[profile]
+	fn(&pref)
+	pf.PerProfile[profile] = pref
+	return pf.Save()
+}
+
+func SetGlobal(fn func(prefs *Preferences)) error {
+	pf, err := Load()
+	if err != nil {
+		return fmt.Errorf("unable to load preferences: %w", err)
+	}
+	fn(&pf.Global)
+	return pf.Save()
+}
+
+func (pf *File) Save() (err error) {
 	root, err := os.UserConfigDir()
 	if err != nil {
 		debug.Println("Unable to compute user preferences dir", err)
@@ -67,5 +113,5 @@ func (p *All) Save() (err error) {
 		}
 	}()
 	debug.Println("saving user preferences to", path)
-	return yaml.NewEncoder(fd).Encode(p)
+	return yaml.NewEncoder(fd).Encode(pf)
 }


### PR DESCRIPTION
## Description

Preferences (`octl kube project use`) are now profile based.

The old preference is still used, but switches to a profile preference when `project use` is called.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [x] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
