### PR TITLE
✨ feat(storage): automatic content-type detection in object put

### DIFF
--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -60,7 +60,7 @@ func init() {
 		return []cobra.Completion{http.MethodGet, http.MethodPut, http.MethodDelete}, cobra.ShellCompDirectiveDefault
 	})
 
-	runner.RegisterHook("auto-content-type", guessContentType)
+	storageCmd.PersistentFlags().Bool("no-auto-content-type", false, "Disable automatic content-type detection")
 }
 
 func callOOS(cmd *cobra.Command, args []string) {
@@ -68,7 +68,11 @@ func callOOS(cmd *cobra.Command, args []string) {
 	p := loadProfile(cmd)
 	cl, err := oos.NewClient(cmd.Context(), p, awsOptions(cmd)...)
 	if err == nil {
-		err = runner.Run[*oos.Client, oos.Error](cmd, args, cl, config.For("storage"))
+		var hooks []runner.Hook
+		if noAuto, _ := cmd.Flags().GetBool("no-auto-content-type"); !noAuto {
+			hooks = []runner.Hook{guessContentType}
+		}
+		err = runner.Run[*oos.Client, oos.Error](cmd, args, cl, config.For("storage"), hooks...)
 	}
 	if err != nil {
 		_ = flags.CloseAll(cmd.Flags())
@@ -123,6 +127,8 @@ func presign(cmd *cobra.Command, args []string) {
 	_, _ = fmt.Fprint(os.Stdout, req.URL)
 }
 
+const detectionBufferSize = 32 * 1024
+
 func guessContentType(arg reflect.Value) {
 	if !arg.CanInterface() {
 		return
@@ -136,7 +142,7 @@ func guessContentType(arg reflect.Value) {
 			messages.Info("cannot compute content-type")
 			return
 		}
-		body, err := io.ReadAll(io.LimitReader(seeker, 200))
+		body, err := io.ReadAll(io.LimitReader(seeker, detectionBufferSize))
 		if err != nil {
 			_, _ = seeker.Seek(0, io.SeekStart) // in case something was read...
 			messages.Info("cannot compute content-type: %v", err)
@@ -147,8 +153,9 @@ func guessContentType(arg reflect.Value) {
 			messages.ExitErr(fmt.Errorf("cannot compute content-type: %w", err))
 			return
 		}
+		mimetype.SetLimit(detectionBufferSize)
 		mime := mimetype.Detect(body)
-		messages.Info("detected mime-type: %s", mime.String())
+		messages.Info("Detected mime-type: %s", mime.String())
 		po.ContentType = new(mime.String())
 	}
 }

--- a/docs/reference/octl_storage.md
+++ b/docs/reference/octl_storage.md
@@ -5,7 +5,8 @@ OUTSCALE Object Storage (OOS) management
 ### Options
 
 ```
-  -h, --help   help for storage
+  -h, --help                   help for storage
+      --no-auto-content-type   Disable automatic content-type detection
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/octl_storage_api.md
+++ b/docs/reference/octl_storage_api.md
@@ -19,6 +19,7 @@ storage api calls
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_AbortMultipartUpload.md
+++ b/docs/reference/octl_storage_api_AbortMultipartUpload.md
@@ -29,6 +29,7 @@ octl storage api AbortMultipartUpload [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_CompleteMultipartUpload.md
+++ b/docs/reference/octl_storage_api_CompleteMultipartUpload.md
@@ -43,6 +43,7 @@ octl storage api CompleteMultipartUpload [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_CopyObject.md
+++ b/docs/reference/octl_storage_api_CopyObject.md
@@ -64,6 +64,7 @@ octl storage api CopyObject [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_CreateBucket.md
+++ b/docs/reference/octl_storage_api_CreateBucket.md
@@ -37,6 +37,7 @@ octl storage api CreateBucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_CreateMultipartUpload.md
+++ b/docs/reference/octl_storage_api_CreateMultipartUpload.md
@@ -53,6 +53,7 @@ octl storage api CreateMultipartUpload [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_DeleteBucket.md
+++ b/docs/reference/octl_storage_api_DeleteBucket.md
@@ -25,6 +25,7 @@ octl storage api DeleteBucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_DeleteBucketCors.md
+++ b/docs/reference/octl_storage_api_DeleteBucketCors.md
@@ -25,6 +25,7 @@ octl storage api DeleteBucketCors [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_DeleteBucketEncryption.md
+++ b/docs/reference/octl_storage_api_DeleteBucketEncryption.md
@@ -25,6 +25,7 @@ octl storage api DeleteBucketEncryption [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_DeleteBucketLifecycle.md
+++ b/docs/reference/octl_storage_api_DeleteBucketLifecycle.md
@@ -25,6 +25,7 @@ octl storage api DeleteBucketLifecycle [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_DeleteBucketPolicy.md
+++ b/docs/reference/octl_storage_api_DeleteBucketPolicy.md
@@ -25,6 +25,7 @@ octl storage api DeleteBucketPolicy [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_DeleteBucketWebsite.md
+++ b/docs/reference/octl_storage_api_DeleteBucketWebsite.md
@@ -25,6 +25,7 @@ octl storage api DeleteBucketWebsite [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_DeleteObject.md
+++ b/docs/reference/octl_storage_api_DeleteObject.md
@@ -33,6 +33,7 @@ octl storage api DeleteObject [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_DeleteObjectTagging.md
+++ b/docs/reference/octl_storage_api_DeleteObjectTagging.md
@@ -27,6 +27,7 @@ octl storage api DeleteObjectTagging [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_GetBucketAcl.md
+++ b/docs/reference/octl_storage_api_GetBucketAcl.md
@@ -25,6 +25,7 @@ octl storage api GetBucketAcl [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_GetBucketCors.md
+++ b/docs/reference/octl_storage_api_GetBucketCors.md
@@ -25,6 +25,7 @@ octl storage api GetBucketCors [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_GetBucketEncryption.md
+++ b/docs/reference/octl_storage_api_GetBucketEncryption.md
@@ -25,6 +25,7 @@ octl storage api GetBucketEncryption [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_GetBucketLifecycleConfiguration.md
+++ b/docs/reference/octl_storage_api_GetBucketLifecycleConfiguration.md
@@ -25,6 +25,7 @@ octl storage api GetBucketLifecycleConfiguration [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_GetBucketLocation.md
+++ b/docs/reference/octl_storage_api_GetBucketLocation.md
@@ -25,6 +25,7 @@ octl storage api GetBucketLocation [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_GetBucketPolicy.md
+++ b/docs/reference/octl_storage_api_GetBucketPolicy.md
@@ -25,6 +25,7 @@ octl storage api GetBucketPolicy [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_GetBucketVersioning.md
+++ b/docs/reference/octl_storage_api_GetBucketVersioning.md
@@ -25,6 +25,7 @@ octl storage api GetBucketVersioning [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_GetBucketWebsite.md
+++ b/docs/reference/octl_storage_api_GetBucketWebsite.md
@@ -25,6 +25,7 @@ octl storage api GetBucketWebsite [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_GetObject.md
+++ b/docs/reference/octl_storage_api_GetObject.md
@@ -44,6 +44,7 @@ octl storage api GetObject [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_GetObjectAcl.md
+++ b/docs/reference/octl_storage_api_GetObjectAcl.md
@@ -28,6 +28,7 @@ octl storage api GetObjectAcl [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_GetObjectLockConfiguration.md
+++ b/docs/reference/octl_storage_api_GetObjectLockConfiguration.md
@@ -25,6 +25,7 @@ octl storage api GetObjectLockConfiguration [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_GetObjectRetention.md
+++ b/docs/reference/octl_storage_api_GetObjectRetention.md
@@ -28,6 +28,7 @@ octl storage api GetObjectRetention [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_GetObjectTagging.md
+++ b/docs/reference/octl_storage_api_GetObjectTagging.md
@@ -28,6 +28,7 @@ octl storage api GetObjectTagging [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_HeadBucket.md
+++ b/docs/reference/octl_storage_api_HeadBucket.md
@@ -25,6 +25,7 @@ octl storage api HeadBucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_HeadObject.md
+++ b/docs/reference/octl_storage_api_HeadObject.md
@@ -44,6 +44,7 @@ octl storage api HeadObject [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_ListBuckets.md
+++ b/docs/reference/octl_storage_api_ListBuckets.md
@@ -27,6 +27,7 @@ octl storage api ListBuckets [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_ListMultipartUploads.md
+++ b/docs/reference/octl_storage_api_ListMultipartUploads.md
@@ -32,6 +32,7 @@ octl storage api ListMultipartUploads [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_ListObjectVersions.md
+++ b/docs/reference/octl_storage_api_ListObjectVersions.md
@@ -33,6 +33,7 @@ octl storage api ListObjectVersions [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_ListObjectsV2.md
+++ b/docs/reference/octl_storage_api_ListObjectsV2.md
@@ -34,6 +34,7 @@ octl storage api ListObjectsV2 [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_ListParts.md
+++ b/docs/reference/octl_storage_api_ListParts.md
@@ -33,6 +33,7 @@ octl storage api ListParts [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_PutBucketAcl.md
+++ b/docs/reference/octl_storage_api_PutBucketAcl.md
@@ -41,6 +41,7 @@ octl storage api PutBucketAcl [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_PutBucketCors.md
+++ b/docs/reference/octl_storage_api_PutBucketCors.md
@@ -33,6 +33,7 @@ octl storage api PutBucketCors [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_PutBucketEncryption.md
+++ b/docs/reference/octl_storage_api_PutBucketEncryption.md
@@ -30,6 +30,7 @@ octl storage api PutBucketEncryption [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_PutBucketLifecycleConfiguration.md
+++ b/docs/reference/octl_storage_api_PutBucketLifecycleConfiguration.md
@@ -52,6 +52,7 @@ octl storage api PutBucketLifecycleConfiguration [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_PutBucketPolicy.md
+++ b/docs/reference/octl_storage_api_PutBucketPolicy.md
@@ -29,6 +29,7 @@ octl storage api PutBucketPolicy [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_PutBucketVersioning.md
+++ b/docs/reference/octl_storage_api_PutBucketVersioning.md
@@ -30,6 +30,7 @@ octl storage api PutBucketVersioning [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_PutBucketWebsite.md
+++ b/docs/reference/octl_storage_api_PutBucketWebsite.md
@@ -38,6 +38,7 @@ octl storage api PutBucketWebsite [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_PutObject.md
+++ b/docs/reference/octl_storage_api_PutObject.md
@@ -63,6 +63,7 @@ octl storage api PutObject [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_PutObjectAcl.md
+++ b/docs/reference/octl_storage_api_PutObjectAcl.md
@@ -44,6 +44,7 @@ octl storage api PutObjectAcl [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_PutObjectLockConfiguration.md
+++ b/docs/reference/octl_storage_api_PutObjectLockConfiguration.md
@@ -33,6 +33,7 @@ octl storage api PutObjectLockConfiguration [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_PutObjectRetention.md
+++ b/docs/reference/octl_storage_api_PutObjectRetention.md
@@ -33,6 +33,7 @@ octl storage api PutObjectRetention [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_PutObjectTagging.md
+++ b/docs/reference/octl_storage_api_PutObjectTagging.md
@@ -32,6 +32,7 @@ octl storage api PutObjectTagging [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_UploadPart.md
+++ b/docs/reference/octl_storage_api_UploadPart.md
@@ -40,6 +40,7 @@ octl storage api UploadPart [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_api_UploadPartCopy.md
+++ b/docs/reference/octl_storage_api_UploadPartCopy.md
@@ -42,6 +42,7 @@ octl storage api UploadPartCopy [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket.md
+++ b/docs/reference/octl_storage_bucket.md
@@ -19,6 +19,7 @@ bucket commands
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_acl.md
+++ b/docs/reference/octl_storage_bucket_acl.md
@@ -19,6 +19,7 @@ acl commands
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_acl_configure.md
+++ b/docs/reference/octl_storage_bucket_acl_configure.md
@@ -36,6 +36,7 @@ octl storage bucket acl configure bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_acl_describe.md
+++ b/docs/reference/octl_storage_bucket_acl_describe.md
@@ -29,6 +29,7 @@ octl storage bucket acl describe bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_cors.md
+++ b/docs/reference/octl_storage_bucket_cors.md
@@ -19,6 +19,7 @@ cors commands
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_cors_configure.md
+++ b/docs/reference/octl_storage_bucket_cors_configure.md
@@ -31,6 +31,7 @@ octl storage bucket cors configure bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_cors_describe.md
+++ b/docs/reference/octl_storage_bucket_cors_describe.md
@@ -29,6 +29,7 @@ octl storage bucket cors describe bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_cors_disable.md
+++ b/docs/reference/octl_storage_bucket_cors_disable.md
@@ -29,6 +29,7 @@ octl storage bucket cors disable bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_create.md
+++ b/docs/reference/octl_storage_bucket_create.md
@@ -38,6 +38,7 @@ octl storage bucket create [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_delete.md
+++ b/docs/reference/octl_storage_bucket_delete.md
@@ -30,6 +30,7 @@ octl storage bucket delete bucket [bucket]... [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_describe.md
+++ b/docs/reference/octl_storage_bucket_describe.md
@@ -29,6 +29,7 @@ octl storage bucket describe bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_encryption.md
+++ b/docs/reference/octl_storage_bucket_encryption.md
@@ -19,6 +19,7 @@ encryption commands
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_encryption_describe.md
+++ b/docs/reference/octl_storage_bucket_encryption_describe.md
@@ -29,6 +29,7 @@ octl storage bucket encryption describe bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_encryption_disable.md
+++ b/docs/reference/octl_storage_bucket_encryption_disable.md
@@ -29,6 +29,7 @@ octl storage bucket encryption disable bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_encryption_enable.md
+++ b/docs/reference/octl_storage_bucket_encryption_enable.md
@@ -29,6 +29,7 @@ octl storage bucket encryption enable bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_lifecycle.md
+++ b/docs/reference/octl_storage_bucket_lifecycle.md
@@ -19,6 +19,7 @@ lifecycle commands
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_lifecycle_configure.md
+++ b/docs/reference/octl_storage_bucket_lifecycle_configure.md
@@ -31,6 +31,7 @@ octl storage bucket lifecycle configure bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_lifecycle_describe.md
+++ b/docs/reference/octl_storage_bucket_lifecycle_describe.md
@@ -29,6 +29,7 @@ octl storage bucket lifecycle describe bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_lifecycle_disable.md
+++ b/docs/reference/octl_storage_bucket_lifecycle_disable.md
@@ -29,6 +29,7 @@ octl storage bucket lifecycle disable bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_list.md
+++ b/docs/reference/octl_storage_bucket_list.md
@@ -31,6 +31,7 @@ octl storage bucket list [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_objectlock.md
+++ b/docs/reference/octl_storage_bucket_objectlock.md
@@ -19,6 +19,7 @@ objectlock commands
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_objectlock_configure.md
+++ b/docs/reference/octl_storage_bucket_objectlock_configure.md
@@ -31,6 +31,7 @@ octl storage bucket objectlock configure bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_objectlock_describe.md
+++ b/docs/reference/octl_storage_bucket_objectlock_describe.md
@@ -29,6 +29,7 @@ octl storage bucket objectlock describe bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_policy.md
+++ b/docs/reference/octl_storage_bucket_policy.md
@@ -19,6 +19,7 @@ policy commands
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_policy_configure.md
+++ b/docs/reference/octl_storage_bucket_policy_configure.md
@@ -32,6 +32,7 @@ octl storage bucket policy configure bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_policy_describe.md
+++ b/docs/reference/octl_storage_bucket_policy_describe.md
@@ -29,6 +29,7 @@ octl storage bucket policy describe bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_policy_disable.md
+++ b/docs/reference/octl_storage_bucket_policy_disable.md
@@ -29,6 +29,7 @@ octl storage bucket policy disable bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_versioning.md
+++ b/docs/reference/octl_storage_bucket_versioning.md
@@ -19,6 +19,7 @@ versioning commands
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_versioning_describe.md
+++ b/docs/reference/octl_storage_bucket_versioning_describe.md
@@ -29,6 +29,7 @@ octl storage bucket versioning describe bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_versioning_disable.md
+++ b/docs/reference/octl_storage_bucket_versioning_disable.md
@@ -29,6 +29,7 @@ octl storage bucket versioning disable bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_versioning_enable.md
+++ b/docs/reference/octl_storage_bucket_versioning_enable.md
@@ -29,6 +29,7 @@ octl storage bucket versioning enable bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_website.md
+++ b/docs/reference/octl_storage_bucket_website.md
@@ -19,6 +19,7 @@ website commands
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_website_configure.md
+++ b/docs/reference/octl_storage_bucket_website_configure.md
@@ -31,6 +31,7 @@ octl storage bucket website configure bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_website_describe.md
+++ b/docs/reference/octl_storage_bucket_website_describe.md
@@ -29,6 +29,7 @@ octl storage bucket website describe bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_bucket_website_disable.md
+++ b/docs/reference/octl_storage_bucket_website_disable.md
@@ -29,6 +29,7 @@ octl storage bucket website disable bucket [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_multipartupload.md
+++ b/docs/reference/octl_storage_multipartupload.md
@@ -19,6 +19,7 @@ multipartupload commands
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_multipartupload_create.md
+++ b/docs/reference/octl_storage_multipartupload_create.md
@@ -51,6 +51,7 @@ octl storage multipartupload create [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_multipartupload_list.md
+++ b/docs/reference/octl_storage_multipartupload_list.md
@@ -37,6 +37,7 @@ octl storage multipartupload list [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object.md
+++ b/docs/reference/octl_storage_object.md
@@ -19,6 +19,7 @@ object commands
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_acl.md
+++ b/docs/reference/octl_storage_object_acl.md
@@ -19,6 +19,7 @@ acl commands
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_acl_configure.md
+++ b/docs/reference/octl_storage_object_acl_configure.md
@@ -32,6 +32,7 @@ octl storage object acl configure key [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_acl_describe.md
+++ b/docs/reference/octl_storage_object_acl_describe.md
@@ -30,6 +30,7 @@ octl storage object acl describe key [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_copy.md
+++ b/docs/reference/octl_storage_object_copy.md
@@ -46,6 +46,7 @@ octl storage object copy bucket_src/key_src key_dst [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_delete.md
+++ b/docs/reference/octl_storage_object_delete.md
@@ -37,6 +37,7 @@ octl storage object delete key [key]... [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_describe.md
+++ b/docs/reference/octl_storage_object_describe.md
@@ -30,6 +30,7 @@ octl storage object describe key [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_download.md
+++ b/docs/reference/octl_storage_object_download.md
@@ -33,6 +33,7 @@ octl storage object download key [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_list.md
+++ b/docs/reference/octl_storage_object_list.md
@@ -37,6 +37,7 @@ octl storage object list [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_presign.md
+++ b/docs/reference/octl_storage_object_presign.md
@@ -26,6 +26,7 @@ octl storage object presign key [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_put.md
+++ b/docs/reference/octl_storage_object_put.md
@@ -55,6 +55,7 @@ octl storage object put key [key]... [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_retention.md
+++ b/docs/reference/octl_storage_object_retention.md
@@ -19,6 +19,7 @@ retention commands
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_retention_configure.md
+++ b/docs/reference/octl_storage_object_retention_configure.md
@@ -31,6 +31,7 @@ octl storage object retention configure key [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_retention_desc.md
+++ b/docs/reference/octl_storage_object_retention_desc.md
@@ -30,6 +30,7 @@ octl storage object retention desc key [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_tagging.md
+++ b/docs/reference/octl_storage_object_tagging.md
@@ -19,6 +19,7 @@ tagging commands
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_tagging_configure.md
+++ b/docs/reference/octl_storage_object_tagging_configure.md
@@ -32,6 +32,7 @@ octl storage object tagging configure key [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_tagging_delete.md
+++ b/docs/reference/octl_storage_object_tagging_delete.md
@@ -30,6 +30,7 @@ octl storage object tagging delete key [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_tagging_describe.md
+++ b/docs/reference/octl_storage_object_tagging_describe.md
@@ -30,6 +30,7 @@ octl storage object tagging describe key [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_object_versions.md
+++ b/docs/reference/octl_storage_object_versions.md
@@ -30,6 +30,7 @@ octl storage object versions [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_part.md
+++ b/docs/reference/octl_storage_part.md
@@ -19,6 +19,7 @@ part commands
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/docs/reference/octl_storage_part_list.md
+++ b/docs/reference/octl_storage_part_list.md
@@ -35,6 +35,7 @@ octl storage part list [flags]
       --interval duration          interval between two watch/waitfor iterations (default 5s)
       --jq string                  jq filter
       --max-pages int              maximum number of pages a command can fetch (default 20)
+      --no-auto-content-type       Disable automatic content-type detection
       --no-upgrade                 do not check for new versions
   -O, --out-file string            redirect output to file
   -o, --output string              output format (raw, json, yaml, table, csv, none, base64, text)

--- a/pkg/runner/hooks.go
+++ b/pkg/runner/hooks.go
@@ -1,23 +1,13 @@
 package runner
 
-import "reflect"
+import (
+	"reflect"
+)
 
 type Hook func(arg reflect.Value)
 
-var registeredHooks map[string]Hook
-
-func init() {
-	registeredHooks = map[string]Hook{}
-}
-
-func RegisterHook(name string, hook Hook) {
-	registeredHooks[name] = hook
-}
-
-func applyHooks(arg reflect.Value, hooks []string) {
-	for _, name := range hooks {
-		if hook, ok := registeredHooks[name]; ok {
-			hook(arg)
-		}
+func applyHooks(arg reflect.Value, hooks ...Hook) {
+	for _, hook := range hooks {
+		hook(arg)
 	}
 }

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -22,14 +22,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func Run[Client any, Error error](cmd *cobra.Command, args []string, cl Client, cfg config.Config) error {
+func Run[Client any, Error error](cmd *cobra.Command, args []string, cl Client, cfg config.Config, hooks ...Hook) error {
 	if cmd.Flags().Lookup("waitfor").Changed {
-		return waitfor[Client, Error](cmd, args, cl, cfg)
+		return waitfor[Client, Error](cmd, args, cl, cfg, hooks...)
 	}
-	return doRun[Client, Error](cmd, args, cl, cfg)
+	return doRun[Client, Error](cmd, args, cl, cfg, hooks...)
 }
 
-func doRun[Client any, Error error](cmd *cobra.Command, args []string, cl Client, cfg config.Config) error {
+func doRun[Client any, Error error](cmd *cobra.Command, args []string, cl Client, cfg config.Config, hooks ...Hook) error {
 	clt := reflect.TypeFor[Client]()
 	m, _ := clt.MethodByName(cmd.Name())
 
@@ -58,7 +58,7 @@ func doRun[Client any, Error error](cmd *cobra.Command, args []string, cl Client
 				arg.Set(reflect.New(argType.Elem()))
 			}
 			if !injected {
-				err := ToStruct(cmd, arg, "")
+				err := ToStruct(cmd, arg, "", hooks...)
 				switch {
 				case err != nil:
 					return err

--- a/pkg/runner/struct.go
+++ b/pkg/runner/struct.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func ToStruct(cmd *cobra.Command, arg reflect.Value, prefix string) error {
+func ToStruct(cmd *cobra.Command, arg reflect.Value, prefix string, hooks ...Hook) error {
 	fs := cmd.Flags()
 	var (
 		err    error
@@ -77,9 +77,7 @@ func ToStruct(cmd *cobra.Command, arg reflect.Value, prefix string) error {
 		})
 	}
 	// apply hooks
-	if hooks, _ := fs.GetStringSlice("hooks"); len(hooks) > 0 {
-		applyHooks(arg, hooks)
-	}
+	applyHooks(arg, hooks...)
 	debug.Println(fmt.Sprintf("ToStruct result: %+v", reflect.Indirect(arg).Interface()))
 	return err
 }

--- a/pkg/runner/waitfor.go
+++ b/pkg/runner/waitfor.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func waitfor[Client any, Error error](cmd *cobra.Command, args []string, cl Client, cfg config.Config) error {
+func waitfor[Client any, Error error](cmd *cobra.Command, args []string, cl Client, cfg config.Config, hooks ...Hook) error {
 	expr, _ := cmd.Flags().GetString("waitfor")
 
 	// force JSON output
@@ -39,7 +39,7 @@ func waitfor[Client any, Error error](cmd *cobra.Command, args []string, cl Clie
 		}
 		buf := &bytes.Buffer{}
 		output.InjectOutput(buf)
-		err := doRun[Client, Error](cmd, args, cl, cfg)
+		err := doRun[Client, Error](cmd, args, cl, cfg, hooks...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

This PR enables automatic content-type detection on `storage object put`. It can be disabled by setting `--no-auto-content-type`.

The flag only has an effect on `object put` and `api PutObject`, but is added on all storage commands to simplify the code.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
