### PR TITLE
👷 ci(autotag): rerun action on edit/label/unlabel

### DIFF
--- a/.github/workflows/pr-auto-tagging.yaml
+++ b/.github/workflows/pr-auto-tagging.yaml
@@ -1,7 +1,14 @@
 name: 🔖 PR autotagging
 
 on:
-  pull_request: null
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - edited
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

The autotag workflow was not reexecuted if the PR title was changed or a label was manually added.

The workflow status stayed as failed even if the problem was fixed.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [x] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
