### PR TITLE
🚸 ux(kube): add --control-plane/--version/--subregions autocompletion

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -1,0 +1,19 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func walkCommandTree(root *cobra.Command, fn func(cmd *cobra.Command)) {
+	fn(root)
+	for _, child := range root.Commands() {
+		walkCommandTree(child, fn)
+	}
+}
+
+func walkCommandTreeWithFlag(root *cobra.Command, flag string, fn func(cmd *cobra.Command)) {
+	walkCommandTree(root, func(cmd *cobra.Command) {
+		if cmd.Flags().Lookup(flag) == nil {
+			return
+		}
+		fn(cmd)
+	})
+}

--- a/cmd/kube.go
+++ b/cmd/kube.go
@@ -72,6 +72,19 @@ func init() {
 
 	// cluster/project use
 	projectCmd.AddCommand(projectUseCmd)
+
+	// control-plane autocompletion
+	walkCommandTreeWithFlag(oksCmd, "control-plane", func(cmd *cobra.Command) {
+		_ = cmd.RegisterFlagCompletionFunc("control-plane", autoCompleteControlPlane)
+	})
+	// subregion autocompletion
+	walkCommandTreeWithFlag(oksCmd, "subregions", func(cmd *cobra.Command) {
+		_ = cmd.RegisterFlagCompletionFunc("subregions", autoCompleteSubregion)
+	})
+	// version autocompletion
+	walkCommandTreeWithFlag(oksCmd, "version", func(cmd *cobra.Command) {
+		_ = cmd.RegisterFlagCompletionFunc("version", autoCompleteVersion)
+	})
 }
 
 func kube(cmd *cobra.Command, args []string) {
@@ -84,6 +97,45 @@ func kube(cmd *cobra.Command, args []string) {
 	if err != nil {
 		messages.ExitErr(err)
 	}
+}
+
+func autoCompleteControlPlane(cmd *cobra.Command, _ []string, _ string) ([]cobra.Completion, cobra.ShellCompDirective) {
+	p := loadProfile(cmd)
+	cl, err := oks.NewClient(p, sdkOptions(cmd)...)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+	resp, err := cl.GetControlPlanePlans(cmd.Context())
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+	return lo.Map(resp.ControlPlanes, func(plan string, _ int) cobra.Completion { return cobra.Completion(plan) }), cobra.ShellCompDirectiveDefault
+}
+
+func autoCompleteSubregion(cmd *cobra.Command, _ []string, _ string) ([]cobra.Completion, cobra.ShellCompDirective) {
+	p := loadProfile(cmd)
+	cl, err := oks.NewClient(p, sdkOptions(cmd)...)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+	resp, err := cl.GetCPSubregions(cmd.Context())
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+	return lo.Map(resp.CPSubregions, func(plan string, _ int) cobra.Completion { return cobra.Completion(plan) }), cobra.ShellCompDirectiveDefault
+}
+
+func autoCompleteVersion(cmd *cobra.Command, _ []string, _ string) ([]cobra.Completion, cobra.ShellCompDirective) {
+	p := loadProfile(cmd)
+	cl, err := oks.NewClient(p, sdkOptions(cmd)...)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+	resp, err := cl.GetKubernetesVersions(cmd.Context())
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+	return lo.Map(resp.Versions, func(v string, _ int) cobra.Completion { return cobra.Completion(v) }), cobra.ShellCompDirectiveDefault
 }
 
 func clusterArgToID(cmd *cobra.Command, args []string) error {

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -80,9 +80,10 @@ func init() {
 	profileAddCmd.Flags().String("region", "eu-west-2", "Region")
 	profileAddCmd.Flags().Bool("default", false, "Sets the new profile as the default")
 	_ = cobra.MarkFlagRequired(profileAddCmd.Flags(), "ak")
-	_ = profileAddCmd.RegisterFlagCompletionFunc("region", func(_ *cobra.Command, _ []string, _ string) ([]cobra.Completion, cobra.ShellCompDirective) {
-		return []cobra.Completion{"eu-west-2", "us-west-1", "us-east-2", "cloudgouv-eu-west-1", "ap-northeast-1"}, cobra.ShellCompDirectiveDefault
-	})
+	_ = profileAddCmd.RegisterFlagCompletionFunc(
+		"region",
+		cobra.FixedCompletions([]cobra.Completion{"eu-west-2", "us-west-1", "us-east-2", "cloudgouv-eu-west-1", "ap-northeast-1"}, cobra.ShellCompDirectiveDefault),
+	)
 }
 
 type profileEntry struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -114,9 +114,10 @@ func init() {
 	rootCmd.PersistentFlags().StringSlice("hooks", nil, "")
 	_ = rootCmd.PersistentFlags().MarkHidden("hooks")
 
-	_ = rootCmd.RegisterFlagCompletionFunc("output", func(_ *cobra.Command, _ []string, _ string) ([]cobra.Completion, cobra.ShellCompDirective) {
-		return []cobra.Completion{"raw", "json", "yaml", "table", "csv", "none", "text"}, cobra.ShellCompDirectiveDefault
-	})
+	_ = rootCmd.RegisterFlagCompletionFunc(
+		"output",
+		cobra.FixedCompletions([]cobra.Completion{"raw", "json", "yaml", "table", "csv", "none", "text"}, cobra.ShellCompDirectiveDefault),
+	)
 
 	_ = rootCmd.RegisterFlagCompletionFunc("profile", func(cmd *cobra.Command, _ []string, _ string) ([]cobra.Completion, cobra.ShellCompDirective) {
 		cf, _ := loadConfig(cmd)

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -53,9 +53,10 @@ func init() {
 	_ = presignCmd.MarkFlagRequired("bucket")
 	presignCmd.Flags().Duration("expires", 0, "URL expiration (e.g. 30s, 1h)")
 	presignCmd.Flags().String("method", http.MethodGet, "Method used to access the presigned URL (GET, PUT, DELETE)")
-	_ = presignCmd.RegisterFlagCompletionFunc("method", func(_ *cobra.Command, _ []string, _ string) ([]cobra.Completion, cobra.ShellCompDirective) {
-		return []cobra.Completion{http.MethodGet, http.MethodPut, http.MethodDelete}, cobra.ShellCompDirectiveDefault
-	})
+	_ = presignCmd.RegisterFlagCompletionFunc(
+		"method",
+		cobra.FixedCompletions([]cobra.Completion{http.MethodGet, http.MethodPut, http.MethodDelete}, cobra.ShellCompDirectiveDefault),
+	)
 
 	storageCmd.PersistentFlags().Bool("no-auto-content-type", false, "Disable automatic content-type detection")
 }


### PR DESCRIPTION
## Description

This PR adds dynamic --control-plane/--version/--subregions autocompletion to `kube cluster` commands.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [x] Other (specify): ux

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
